### PR TITLE
Collect "InnerRingUpdate" calls from inner ring nodes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,12 +91,6 @@ PASS
 ok      github.com/nspcc-dev/neofs-contract     0.453s
 ```
 
-### Skipped tests
-
-Some tests might be skipped for now. These tests used `neofs-node` 
-structures, that are not publicly available yet, e.g. cheque for 
-`InnerRingUpdate` call.
-
 ## License
 
 This project is licensed under the GPLv3 License - see the 


### PR DESCRIPTION
Inner ring nodes do not collect signatures for the cheque now. Instead they invoke "InnerRingUpdate" method and smart-contract checks if method was called from inner ring node. Then it accepts cheque if there were 2/3n+1 invokes.