### PR TITLE
Add snapshot getter by epoch number

### DIFF
--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -273,6 +273,12 @@ func Snapshot(diff int) []storageNode {
 	return getSnapshot(ctx, key)
 }
 
+func SnapshotByEpoch(epoch int) []storageNode {
+	currentEpoch := storage.Get(ctx, snapshotEpoch).(int)
+
+	return Snapshot(currentEpoch - epoch)
+}
+
 func Config(key []byte) interface{} {
 	return getConfig(ctx, key)
 }


### PR DESCRIPTION
There are cases when NeoFS applications need to fetch netmap snapshot of exact epoch. This method provides convenient atomic
way to do that. 

Related to https://github.com/nspcc-dev/neofs-node/issues/234