### PR TITLE
Produce notification to control container estimations

### DIFF
--- a/container/config.yml
+++ b/container/config.yml
@@ -15,3 +15,11 @@ events:
         type: ByteArray
       - name: signature
         type: ByteArray
+  - name: StartEstimation
+    parameters:
+      - name: epoch
+        type: Integer
+  - name: StopEstimation
+    parameters:
+      - name: epoch
+        type: Integer


### PR DESCRIPTION
Basic income settlements depends on container estimation that should be collected in P2P communication between storage nodes
and then stored in container contract. To synchronize these actions there are two separate notification that inner ring should produce in consensus.