### PR TITLE
Fix processing order in voting

### DIFF
--- a/balance/balance_contract.go
+++ b/balance/balance_contract.go
@@ -413,6 +413,11 @@ func vote(ctx storage.Context, id, from []byte) int {
 
 	for i := 0; i < len(candidates); i++ {
 		cnd := candidates[i]
+
+		if blockHeight-cnd.block > blockDiff {
+			continue
+		}
+
 		if bytesEqual(cnd.id, id) {
 			voters := cnd.n
 
@@ -427,10 +432,7 @@ func vote(ctx storage.Context, id, from []byte) int {
 			found = len(voters)
 		}
 
-		// do not add old ballots, they are invalid
-		if blockHeight-cnd.block <= blockDiff {
-			newCandidates = append(newCandidates, cnd)
-		}
+		newCandidates = append(newCandidates, cnd)
 	}
 
 	if found < 0 {

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -502,6 +502,11 @@ func vote(ctx storage.Context, id, from []byte) int {
 
 	for i := 0; i < len(candidates); i++ {
 		cnd := candidates[i]
+
+		if blockHeight-cnd.block > blockDiff {
+			continue
+		}
+
 		if bytesEqual(cnd.id, id) {
 			voters := cnd.n
 
@@ -516,10 +521,7 @@ func vote(ctx storage.Context, id, from []byte) int {
 			found = len(voters)
 		}
 
-		// do not add old ballots, they are invalid
-		if blockHeight-cnd.block <= blockDiff {
-			newCandidates = append(newCandidates, cnd)
-		}
+		newCandidates = append(newCandidates, cnd)
 	}
 
 	if found < 0 {

--- a/neofs/neofs_contract.go
+++ b/neofs/neofs_contract.go
@@ -556,6 +556,11 @@ func vote(ctx storage.Context, id, from []byte) int {
 
 	for i := 0; i < len(candidates); i++ {
 		cnd := candidates[i]
+
+		if blockHeight-cnd.block > blockDiff {
+			continue
+		}
+
 		if bytesEqual(cnd.id, id) {
 			voters := cnd.n
 
@@ -570,10 +575,7 @@ func vote(ctx storage.Context, id, from []byte) int {
 			found = len(voters)
 		}
 
-		// do not add old ballots, they are invalid
-		if blockHeight-cnd.block <= blockDiff {
-			newCandidates = append(newCandidates, cnd)
-		}
+		newCandidates = append(newCandidates, cnd)
 	}
 
 	if found < 0 {

--- a/neofsid/neofsid_contract.go
+++ b/neofsid/neofsid_contract.go
@@ -231,6 +231,11 @@ func vote(ctx storage.Context, id, from []byte) int {
 
 	for i := 0; i < len(candidates); i++ {
 		cnd := candidates[i]
+
+		if blockHeight-cnd.block > blockDiff {
+			continue
+		}
+
 		if bytesEqual(cnd.id, id) {
 			voters := cnd.n
 
@@ -245,10 +250,7 @@ func vote(ctx storage.Context, id, from []byte) int {
 			found = len(voters)
 		}
 
-		// do not add old ballots, they are invalid
-		if blockHeight-cnd.block <= blockDiff {
-			newCandidates = append(newCandidates, cnd)
-		}
+		newCandidates = append(newCandidates, cnd)
 	}
 
 	if found < 0 {

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -431,6 +431,11 @@ func vote(ctx storage.Context, id, from []byte) int {
 
 	for i := 0; i < len(candidates); i++ {
 		cnd := candidates[i]
+
+		if blockHeight-cnd.block > blockDiff {
+			continue
+		}
+
 		if bytesEqual(cnd.id, id) {
 			voters := cnd.n
 
@@ -445,10 +450,7 @@ func vote(ctx storage.Context, id, from []byte) int {
 			found = len(voters)
 		}
 
-		// do not add old ballots, they are invalid
-		if blockHeight-cnd.block <= blockDiff {
-			newCandidates = append(newCandidates, cnd)
-		}
+		newCandidates = append(newCandidates, cnd)
 	}
 
 	if found < 0 {


### PR DESCRIPTION
Remove old ballots first so there won't be any
interference with votes of the same tx in the
future after `blockDiff` blocks.

Signed-off-by: Alex Vanin <alexey@nspcc.ru>