### PR TITLE
Run cleanup routines on new epoch

### DIFF
--- a/balance/balance_contract.go
+++ b/balance/balance_contract.go
@@ -168,7 +168,7 @@ func NewEpoch(epochNum int) bool {
 
 	multiaddr := common.InnerRingMultiAddressViaStorage(ctx, netmapContractKey)
 	if !runtime.CheckWitness(multiaddr) {
-		panic("epochNum: this method must be invoked from inner ring")
+		panic("newEpoch: this method must be invoked from inner ring")
 	}
 
 	it := storage.Find(ctx, []byte{}, storage.KeysOnly)

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -331,12 +331,12 @@ func ListContainerSizes(epoch int) [][]byte {
 	return result
 }
 
-func ProcessEpoch(epochNum int) {
+func NewEpoch(epochNum int) {
 	ctx := storage.GetContext()
 
 	multiaddr := common.InnerRingMultiAddressViaStorage(ctx, netmapContractKey)
 	if !runtime.CheckWitness(multiaddr) {
-		panic("processEpoch: this method must be invoked from inner ring")
+		panic("newEpoch: this method must be invoked from inner ring")
 	}
 
 	candidates := keysToDelete(ctx, epochNum)

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -112,8 +112,8 @@ func Put(container []byte, signature interop.Signature, publicKey interop.Public
 	}
 
 	from := walletToScriptHash(ownerID)
-	netmapContractAddr := storage.Get(ctx, netmapContractKey).([]byte)
-	balanceContractAddr := storage.Get(ctx, balanceContractKey).([]byte)
+	netmapContractAddr := storage.Get(ctx, netmapContractKey).(interop.Hash160)
+	balanceContractAddr := storage.Get(ctx, balanceContractKey).(interop.Hash160)
 	containerFee := contract.Call(netmapContractAddr, "config", contract.ReadOnly, containerFeeKey).(int)
 
 	// todo: check if new container with unique container id
@@ -154,7 +154,7 @@ func Delete(containerID, signature []byte) bool {
 	multiaddr := common.InnerRingMultiAddressViaStorage(ctx, netmapContractKey)
 	if !runtime.CheckWitness(multiaddr) {
 		// check provided key
-		neofsIDContractAddr := storage.Get(ctx, neofsIDContractKey).([]byte)
+		neofsIDContractAddr := storage.Get(ctx, neofsIDContractKey).(interop.Hash160)
 		keys := contract.Call(neofsIDContractAddr, "key", contract.ReadOnly, ownerID).([]interop.PublicKey)
 
 		if !verifySignature(containerID, signature, keys) {

--- a/neofsid/neofsid_contract.go
+++ b/neofsid/neofsid_contract.go
@@ -2,7 +2,6 @@ package neofsidcontract
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/interop"
-	"github.com/nspcc-dev/neo-go/pkg/interop/native/crypto"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
 	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
@@ -154,29 +153,4 @@ func getUserInfo(ctx storage.Context, key interface{}) UserInfo {
 	}
 
 	return UserInfo{Keys: [][]byte{}}
-}
-
-func invokeIDKeys(owner []byte, keys [][]byte, prefix []byte) []byte {
-	prefix = append(prefix, owner...)
-	for i := range keys {
-		prefix = append(prefix, keys[i]...)
-	}
-
-	return crypto.Sha256(prefix)
-}
-
-func fromKnownContract(caller []byte) bool {
-	ctx := storage.GetReadOnlyContext()
-
-	containerContractAddr := storage.Get(ctx, containerContractKey).([]byte)
-	if common.BytesEqual(caller, containerContractAddr) {
-		return true
-	}
-
-	return false
-}
-
-func irList() []common.IRNode {
-	ctx := storage.GetReadOnlyContext()
-	return common.InnerRingListViaStorage(ctx, netmapContractKey)
 }


### PR DESCRIPTION
Closes #53 

Additionally: 
- remove unused code from neofsid contract after notary update,
- use `interop.Hash160` type for contract addresses fetched from storage in container contract.