### PR TITLE
Fix init arguments in contracts

### DIFF
--- a/audit/audit_contract.go
+++ b/audit/audit_contract.go
@@ -36,23 +36,16 @@ func (a auditHeader) ID() []byte {
 
 const (
 	version = 1
-
-	netmapContractKey = "netmapScriptHash"
 )
 
-func Init(owner interop.Hash160, addrNetmap interop.Hash160) {
+func Init(owner interop.Hash160) {
 	ctx := storage.GetContext()
 
 	if !common.HasUpdateAccess(ctx) {
 		panic("only owner can reinitialize contract")
 	}
 
-	if len(addrNetmap) != 20 {
-		panic("init: incorrect length of contract script hash")
-	}
-
 	storage.Put(ctx, common.OwnerKey, owner)
-	storage.Put(ctx, netmapContractKey, addrNetmap)
 
 	runtime.Log("audit contract initialized")
 }
@@ -145,7 +138,6 @@ func list(it iterator.Iterator) [][]byte {
 	var result [][]byte
 
 	ignore := [][]byte{
-		[]byte(netmapContractKey),
 		[]byte(common.OwnerKey),
 	}
 

--- a/balance/balance_contract.go
+++ b/balance/balance_contract.go
@@ -37,9 +37,6 @@ const (
 	decimals    = 12
 	circulation = "MainnetGAS"
 	version     = 1
-
-	netmapContractKey    = "netmapScriptHash"
-	containerContractKey = "containerScriptHash"
 )
 
 var (
@@ -62,20 +59,14 @@ func init() {
 	token = CreateToken()
 }
 
-func Init(owner, addrNetmap, addrContainer interop.Hash160) {
+func Init(owner interop.Hash160) {
 	ctx := storage.GetContext()
 
 	if !common.HasUpdateAccess(ctx) {
 		panic("only owner can reinitialize contract")
 	}
 
-	if len(addrNetmap) != 20 || len(addrContainer) != 20 {
-		panic("init: incorrect length of contract script hash")
-	}
-
 	storage.Put(ctx, common.OwnerKey, owner)
-	storage.Put(ctx, netmapContractKey, addrNetmap)
-	storage.Put(ctx, containerContractKey, addrContainer)
 
 	runtime.Log("balance contract initialized")
 }

--- a/neofsid/neofsid_contract.go
+++ b/neofsid/neofsid_contract.go
@@ -17,25 +17,16 @@ type (
 
 const (
 	version = 1
-
-	netmapContractKey    = "netmapScriptHash"
-	containerContractKey = "containerScriptHash"
 )
 
-func Init(owner, addrNetmap, addrContainer interop.Hash160) {
+func Init(owner interop.Hash160) {
 	ctx := storage.GetContext()
 
 	if !common.HasUpdateAccess(ctx) {
 		panic("only owner can reinitialize contract")
 	}
 
-	if len(addrNetmap) != 20 || len(addrContainer) != 20 {
-		panic("init: incorrect length of contract script hash")
-	}
-
 	storage.Put(ctx, common.OwnerKey, owner)
-	storage.Put(ctx, netmapContractKey, addrNetmap)
-	storage.Put(ctx, containerContractKey, addrContainer)
 
 	runtime.Log("neofsid contract initialized")
 }

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -229,7 +229,7 @@ func Config(key []byte) interface{} {
 	return getConfig(ctx, key)
 }
 
-func SetConfig(id, key, val []byte) bool {
+func SetConfig(key, val []byte) bool {
 	multiaddr := common.AlphabetAddress()
 	if !runtime.CheckWitness(multiaddr) {
 		panic("setConfig: invoked by non inner ring node")

--- a/proxy/proxy_contract.go
+++ b/proxy/proxy_contract.go
@@ -12,8 +12,6 @@ import (
 
 const (
 	version = 1
-
-	netmapContractKey = "netmapScriptHash"
 )
 
 func OnNEP17Payment(from interop.Hash160, amount int, data interface{}) {
@@ -23,19 +21,14 @@ func OnNEP17Payment(from interop.Hash160, amount int, data interface{}) {
 	}
 }
 
-func Init(owner, addrNetmap interop.Hash160) {
+func Init(owner interop.Hash160) {
 	ctx := storage.GetContext()
 
 	if !common.HasUpdateAccess(ctx) {
 		panic("only owner can reinitialize contract")
 	}
 
-	if len(addrNetmap) != 20 {
-		panic("init: incorrect length of contract script hash")
-	}
-
 	storage.Put(ctx, common.OwnerKey, owner)
-	storage.Put(ctx, netmapContractKey, addrNetmap)
 
 	runtime.Log("proxy contract initialized")
 }


### PR DESCRIPTION
With changes in governance and multi signature collection via notary contract, several init arguments become redundant. 