### PR TITLE
Unify transfer deatails format

### DIFF
--- a/common/transfer.go
+++ b/common/transfer.go
@@ -1,0 +1,34 @@
+package common
+
+var (
+	mintPrefix         = []byte{0x01}
+	burnPrefix         = []byte{0x02}
+	lockPrefix         = []byte{0x03}
+	unlockPrefix       = []byte{0x04}
+	containerFeePrefix = []byte{0x10}
+)
+
+func WalletToScriptHash(wallet []byte) []byte {
+	return wallet[1 : len(wallet)-4]
+}
+
+func MintTransferDetails(txDetails []byte) []byte {
+	return append(mintPrefix, txDetails...)
+}
+
+func BurnTransferDetails(txDetails []byte) []byte {
+	return append(burnPrefix, txDetails...)
+}
+
+func LockTransferDetails(txDetails []byte) []byte {
+	return append(lockPrefix, txDetails...)
+}
+
+func UnlockTransferDetails(epoch int) []byte {
+	var buf interface{} = epoch
+	return append(unlockPrefix, buf.([]byte)...)
+}
+
+func ContainerFeeTransferDetails(cid []byte) []byte {
+	return append(containerFeePrefix, cid...)
+}


### PR DESCRIPTION
Unified format uses transfer type as the first byte and extra details next. List of transfer types used in contracts defined in `transfer.go`. It includes:
- mint,
- burn,
- lock,
- unlock,
- container fee.