### PR TITLE
Add netmap candidate list getter

### DIFF
--- a/netmap/config.yml
+++ b/netmap/config.yml
@@ -1,5 +1,5 @@
 name: "NeoFS Netmap"
-safemethods: ["innerRingList", "epoch", "netmap", "snapshot", "snapshotByEpoch", "config", "listConfig", "version"]
+safemethods: ["innerRingList", "epoch", "netmap", "netmapCandidates", "snapshot", "snapshotByEpoch", "config", "listConfig", "version"]
 events:
   - name: AddPeer
     parameters:

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -351,6 +351,13 @@ func Netmap() []storageNode {
 	return getSnapshot(ctx, snapshot0Key)
 }
 
+// NetmapCandidates returns all node candidates for next epoch and their
+// status codes.
+func NetmapCandidates() []netmapNode {
+	ctx := storage.GetReadOnlyContext()
+	return getNetmapNodes(ctx)
+}
+
 func Snapshot(diff int) []storageNode {
 	var key string
 


### PR DESCRIPTION
With `NetmapCandidate` storage nodes can monitor if they are expected to be in the netmap at next epoch or not. This is also important for monitoring when some nodes does not bootstrap immediately.

Closes #66 