### PR TITLE
Fix parameter types in notification manifest

### DIFF
--- a/container/config.yml
+++ b/container/config.yml
@@ -6,9 +6,9 @@ events:
       - name: container
         type: ByteArray
       - name: signature
-        type: ByteArray
+        type: Signature
       - name: publicKey
-        type: ByteArray
+        type: PublicKey
       - name: token
         type: ByteArray
   - name: containerDelete
@@ -16,7 +16,7 @@ events:
       - name: containerID
         type: ByteArray
       - name: signature
-        type: ByteArray
+        type: Signature
       - name: token
         type: ByteArray
   - name: setEACL
@@ -24,9 +24,9 @@ events:
       - name: eACL
         type: ByteArray
       - name: signature
-        type: ByteArray
+        type: Signature
       - name: publicKey
-        type: ByteArray
+        type: PublicKey
       - name: token
         type: ByteArray
   - name: StartEstimation

--- a/neofs/config.yml
+++ b/neofs/config.yml
@@ -14,7 +14,7 @@ events:
   - name: Withdraw
     parameters:
       - name: user
-        type: ByteArray
+        type: Hash160
       - name: amount
         type: Integer
       - name: txHash
@@ -24,7 +24,7 @@ events:
       - name: id
         type: ByteArray
       - name: user
-        type: ByteArray
+        type: Hash160
       - name: amount
         type: Integer
       - name: lockAccount

--- a/netmap/config.yml
+++ b/netmap/config.yml
@@ -10,7 +10,7 @@ events:
       - name: state
         type: Integer
       - name: publicKey
-        type: ByteArray
+        type: PublicKey
   - name: NewEpoch
     parameters:
       - name: epoch


### PR DESCRIPTION
neo-go v0.95.2+ has strict notification type checker enabled by default.

Closes #93 