### PR TITLE
Specify permissions in contract manifests

### DIFF
--- a/alphabet/config.yml
+++ b/alphabet/config.yml
@@ -1,2 +1,4 @@
 name: "NeoFS Alphabet"
 safemethods: ["gas", "neo", "name", "version"]
+permissions:
+  - methods: ["update", "transfer", "vote"]

--- a/audit/config.yml
+++ b/audit/config.yml
@@ -1,2 +1,4 @@
 name: "NeoFS Audit"
 safemethods: ["get", "list", "listByEpoch", "listByCID", "listByNode", "version"]
+permissions:
+  - methods: ["update"]

--- a/balance/config.yml
+++ b/balance/config.yml
@@ -1,6 +1,8 @@
 name: "NeoFS Balance"
 supportedstandards: ["NEP-17"]
 safemethods: ["balanceOf", "decimals", "symbol", "totalSupply", "version"]
+permissions:
+  - methods: ["update"]
 events:
   - name: Lock
     parameters:

--- a/container/config.yml
+++ b/container/config.yml
@@ -1,5 +1,7 @@
 name: "NeoFS Container"
 safemethods: ["get", "owner", "list", "eACL", "getContainerSize", "listContainerSizes", "version"]
+permissions:
+  - methods: ["update", "addKey", "transferX"]
 events:
   - name: containerPut
     parameters:

--- a/neofs/config.yml
+++ b/neofs/config.yml
@@ -1,5 +1,7 @@
 name: "NeoFS"
 safemethods: ["alphabetList", "alphabetAddress", "innerRingCandidates", "config", "listConfig", "version"]
+permissions:
+  - methods: ["update", "transfer"]
 events:
   - name: Deposit
     parameters:

--- a/neofsid/config.yml
+++ b/neofsid/config.yml
@@ -1,2 +1,4 @@
 name: "NeoFS ID"
 safemethods: ["key", "version"]
+permissions:
+  - methods: ["update"]

--- a/netmap/config.yml
+++ b/netmap/config.yml
@@ -1,5 +1,7 @@
 name: "NeoFS Netmap"
 safemethods: ["innerRingList", "epoch", "netmap", "netmapCandidates", "snapshot", "snapshotByEpoch", "config", "listConfig", "version"]
+permissions:
+  - methods: ["update", "newEpoch"]
 events:
   - name: AddPeer
     parameters:

--- a/processing/config.yml
+++ b/processing/config.yml
@@ -1,2 +1,4 @@
 name: "NeoFS Multi Signature Processing"
 safemethods: ["verify", "version"]
+permissions:
+  - methods: ["update"]

--- a/proxy/config.yml
+++ b/proxy/config.yml
@@ -1,2 +1,4 @@
 name: "NeoFS Notary Proxy"
 safemethods: ["verify", "version"]
+permissions:
+  - methods: ["update"]

--- a/reputation/config.yml
+++ b/reputation/config.yml
@@ -1,5 +1,7 @@
 name: "NeoFS Reputation"
 safemethods: ["get, getByID, listByEpoch"]
+permissions:
+  - methods: ["update"]
 events:
   - name: reputationPut
     parameters:


### PR DESCRIPTION
Before neo-go v0.95.2 all permissions were '*', but it has been changed. 