### PR TITLE
Make `AddPeer` stable for simultaneous invocations in one block

### DIFF
--- a/alphabet/alphabet_contract.go
+++ b/alphabet/alphabet_contract.go
@@ -82,7 +82,7 @@ func Migrate(script []byte, manifest []byte, data interface{}) bool {
 		return false
 	}
 
-	management.UpdateWithData(script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
 	runtime.Log("alphabet contract updated")
 
 	return true

--- a/audit/audit_contract.go
+++ b/audit/audit_contract.go
@@ -2,6 +2,7 @@ package auditcontract
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/interop"
+	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
 	"github.com/nspcc-dev/neo-go/pkg/interop/iterator"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/crypto"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
@@ -82,7 +83,7 @@ func Migrate(script []byte, manifest []byte, data interface{}) bool {
 		return false
 	}
 
-	management.UpdateWithData(script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
 	runtime.Log("audit contract updated")
 
 	return true

--- a/balance/balance_contract.go
+++ b/balance/balance_contract.go
@@ -2,6 +2,7 @@ package balancecontract
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/interop"
+	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
 	"github.com/nspcc-dev/neo-go/pkg/interop/iterator"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
@@ -101,7 +102,7 @@ func Migrate(script []byte, manifest []byte, data interface{}) bool {
 		return false
 	}
 
-	management.UpdateWithData(script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
 	runtime.Log("balance contract updated")
 
 	return true

--- a/neofs/neofs_contract.go
+++ b/neofs/neofs_contract.go
@@ -65,7 +65,7 @@ const (
 
 	publicKeySize = 33
 
-	maxBalanceAmount = 9000 // Max integer of Fixed12 in JSON bound (2**53-1)
+	maxBalanceAmount    = 9000 // Max integer of Fixed12 in JSON bound (2**53-1)
 	maxBalanceAmountGAS = maxBalanceAmount * 1_0000_0000
 
 	// hardcoded value to ignore deposit notification in onReceive
@@ -138,7 +138,7 @@ func Migrate(script []byte, manifest []byte, data interface{}) bool {
 		return false
 	}
 
-	management.UpdateWithData(script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
 	runtime.Log("neofs contract updated")
 
 	return true

--- a/neofsid/neofsid_contract.go
+++ b/neofsid/neofsid_contract.go
@@ -2,6 +2,7 @@ package neofsidcontract
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/interop"
+	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/crypto"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
@@ -67,7 +68,7 @@ func Migrate(script []byte, manifest []byte, data interface{}) bool {
 		return false
 	}
 
-	management.UpdateWithData(script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
 	runtime.Log("neofsid contract updated")
 
 	return true

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -120,7 +120,7 @@ func Migrate(script []byte, manifest []byte, data interface{}) bool {
 		return false
 	}
 
-	management.UpdateWithData(script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
 	runtime.Log("netmap contract updated")
 
 	return true

--- a/processing/processing_contract.go
+++ b/processing/processing_contract.go
@@ -58,7 +58,7 @@ func Migrate(script []byte, manifest []byte, data interface{}) bool {
 		return false
 	}
 
-	management.UpdateWithData(script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
 	runtime.Log("processing contract updated")
 
 	return true

--- a/proxy/proxy_contract.go
+++ b/proxy/proxy_contract.go
@@ -2,6 +2,7 @@ package proxycontract
 
 import (
 	"github.com/nspcc-dev/neo-go/pkg/interop"
+	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/gas"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/neo"
@@ -56,7 +57,7 @@ func Migrate(script []byte, manifest []byte, data interface{}) bool {
 		return false
 	}
 
-	management.UpdateWithData(script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
 	runtime.Log("proxy contract updated")
 
 	return true


### PR DESCRIPTION
- [x] Add migration routine from v0.9.1