### PR TITLE
Fix Makefile after NNS contract

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ nns_sc = nns
 
 define sc_template
 $(2)$(1)/$(1)_contract.nef: $(2)$(1)/$(1)_contract.go
-	$(NEOGO) contract compile -i $(2)$(1) -c $(if $(2),$(2),$(1)/)config.yml -m $(2)$(1)/config.json
+	$(NEOGO) contract compile -i $(2)$(1) -c $(if $(2),$(2),$(1)/)config.yml -m $(2)$(1)/config.json -o $(2)$(1)/$(1)_contract.nef
 
 $(if $(2),$(2)$(1)/$(1)_contract.go: alphabet/alphabet.go alphabet/alphabet.tpl
 	go run alphabet/alphabet.go


### PR DESCRIPTION
Without -o flag neo-go compiles contracts into `out.nef` file in the repository root.