### PR TITLE
Makefile: allow target for creating release archive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 SHELL=bash
 NEOGO?=neo-go
+VERSION?=$(shell git describe --tags)
 
 .PHONY: all build sidechain
 build: all
@@ -40,3 +41,8 @@ mr_proper: clean
 	for sc in $(alphabet_sc); do\
 	  rm -rf alphabet/$$sc; \
 	done
+
+archive: build
+	@tar --transform "s|^./|neofs-contract-$(VERSION)/|" \
+		-czf neofs-contract-$(VERSION).tar.gz \
+		$(shell find . -name '*.nef' -o -name 'config.json')


### PR DESCRIPTION
Close #95. 

This is something I used for myself, we can alter it in future if needed.
It contains only *.nef and *.json files.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>