### PR TITLE
Remove contract owners

### DIFF
--- a/alphabet/alphabet_contract.go
+++ b/alphabet/alphabet_contract.go
@@ -39,24 +39,18 @@ func _deploy(data interface{}, isUpdate bool) {
 
 	args := data.([]interface{})
 	notaryDisabled := args[0].(bool)
-	owner := args[1].(interop.Hash160)
-	addrNetmap := args[2].(interop.Hash160)
-	addrProxy := args[3].(interop.Hash160)
-	name := args[4].(string)
-	index := args[5].(int)
-	total := args[6].(int)
+	addrNetmap := args[1].(interop.Hash160)
+	addrProxy := args[2].(interop.Hash160)
+	name := args[3].(string)
+	index := args[4].(int)
+	total := args[5].(int)
 
 	ctx := storage.GetContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can reinitialize contract")
-	}
 
 	if len(addrNetmap) != 20 || !notaryDisabled && len(addrProxy) != 20 {
 		panic("incorrect length of contract script hash")
 	}
 
-	storage.Put(ctx, common.OwnerKey, owner)
 	storage.Put(ctx, netmapKey, addrNetmap)
 	storage.Put(ctx, proxyKey, addrProxy)
 	storage.Put(ctx, nameKey, name)
@@ -74,12 +68,10 @@ func _deploy(data interface{}, isUpdate bool) {
 }
 
 // Update method updates contract source code and manifest. Can be invoked
-// only by contract owner.
+// only by committee.
 func Update(script []byte, manifest []byte, data interface{}) {
-	ctx := storage.GetReadOnlyContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can update contract")
+	if !common.HasUpdateAccess() {
+		panic("only committee can update contract")
 	}
 
 	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)

--- a/balance/balance_contract.go
+++ b/balance/balance_contract.go
@@ -65,21 +65,15 @@ func _deploy(data interface{}, isUpdate bool) {
 
 	args := data.([]interface{})
 	notaryDisabled := args[0].(bool)
-	owner := args[1].(interop.Hash160)
-	addrNetmap := args[2].(interop.Hash160)
-	addrContainer := args[3].(interop.Hash160)
+	addrNetmap := args[1].(interop.Hash160)
+	addrContainer := args[2].(interop.Hash160)
 
 	ctx := storage.GetContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can reinitialize contract")
-	}
 
 	if len(addrNetmap) != 20 || len(addrContainer) != 20 {
 		panic("init: incorrect length of contract script hash")
 	}
 
-	storage.Put(ctx, common.OwnerKey, owner)
 	storage.Put(ctx, netmapContractKey, addrNetmap)
 	storage.Put(ctx, containerContractKey, addrContainer)
 
@@ -94,12 +88,10 @@ func _deploy(data interface{}, isUpdate bool) {
 }
 
 // Update method updates contract source code and manifest. Can be invoked
-// only by contract owner.
+// only by committee.
 func Update(script []byte, manifest []byte, data interface{}) {
-	ctx := storage.GetReadOnlyContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can update contract")
+	if !common.HasUpdateAccess() {
+		panic("only committee can update contract")
 	}
 
 	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)

--- a/common/ir.go
+++ b/common/ir.go
@@ -55,6 +55,12 @@ func AlphabetAddress() []byte {
 	return Multiaddress(alphabet, false)
 }
 
+// CommitteeAddress returns multi address of committee.
+func CommitteeAddress() []byte {
+	committee := neo.GetCommittee()
+	return Multiaddress(committee, true)
+}
+
 // Multiaddress returns default multi signature account address for N keys.
 // If committee set to true, then it is `M = N/2+1` committee account.
 func Multiaddress(n []interop.PublicKey, committee bool) []byte {
@@ -63,12 +69,7 @@ func Multiaddress(n []interop.PublicKey, committee bool) []byte {
 		threshold = len(n)/2 + 1
 	}
 
-	keys := []interop.PublicKey{}
-	for _, key := range n {
-		keys = append(keys, key)
-	}
-
-	return contract.CreateMultisigAccount(threshold, keys)
+	return contract.CreateMultisigAccount(threshold, n)
 }
 
 func keysToNodes(list []interop.PublicKey) []IRNode {

--- a/common/update.go
+++ b/common/update.go
@@ -1,22 +1,10 @@
 package common
 
 import (
-	"github.com/nspcc-dev/neo-go/pkg/interop"
 	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
-	"github.com/nspcc-dev/neo-go/pkg/interop/storage"
 )
 
-const OwnerKey = "contractOwner"
-
-// HasUpdateAccess returns true if contract can be initialized, re-initialized
-// or migrated.
-func HasUpdateAccess(ctx storage.Context) bool {
-	data := storage.Get(ctx, OwnerKey)
-	if data == nil { // contract has not been initialized yet, return true
-		return true
-	}
-
-	owner := data.(interop.Hash160)
-
-	return runtime.CheckWitness(owner)
+// HasUpdateAccess returns true if contract can be updated.
+func HasUpdateAccess() bool {
+	return runtime.CheckWitness(CommitteeAddress())
 }

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -70,20 +70,14 @@ func _deploy(data interface{}, isUpdate bool) {
 
 	args := data.([]interface{})
 	notaryDisabled := args[0].(bool)
-	owner := args[1].(interop.Hash160)
-	addrNetmap := args[2].(interop.Hash160)
-	addrBalance := args[3].(interop.Hash160)
-	addrID := args[4].(interop.Hash160)
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can reinitialize contract")
-	}
+	addrNetmap := args[1].(interop.Hash160)
+	addrBalance := args[2].(interop.Hash160)
+	addrID := args[3].(interop.Hash160)
 
 	if len(addrNetmap) != 20 || len(addrBalance) != 20 || len(addrID) != 20 {
 		panic("incorrect length of contract script hash")
 	}
 
-	storage.Put(ctx, common.OwnerKey, owner)
 	storage.Put(ctx, netmapContractKey, addrNetmap)
 	storage.Put(ctx, balanceContractKey, addrBalance)
 	storage.Put(ctx, neofsIDContractKey, addrID)
@@ -99,12 +93,10 @@ func _deploy(data interface{}, isUpdate bool) {
 }
 
 // Update method updates contract source code and manifest. Can be invoked
-// only by contract owner.
+// only by committee.
 func Update(script []byte, manifest []byte, data interface{}) {
-	ctx := storage.GetReadOnlyContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can update contract")
+	if !common.HasUpdateAccess() {
+		panic("only committee can update contract")
 	}
 
 	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)

--- a/neofsid/neofsid_contract.go
+++ b/neofsid/neofsid_contract.go
@@ -30,21 +30,15 @@ func _deploy(data interface{}, isUpdate bool) {
 
 	args := data.([]interface{})
 	notaryDisabled := args[0].(bool)
-	owner := args[1].(interop.Hash160)
-	addrNetmap := args[2].(interop.Hash160)
-	addrContainer := args[3].(interop.Hash160)
+	addrNetmap := args[1].(interop.Hash160)
+	addrContainer := args[2].(interop.Hash160)
 
 	ctx := storage.GetContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can reinitialize contract")
-	}
 
 	if len(addrNetmap) != 20 || len(addrContainer) != 20 {
 		panic("init: incorrect length of contract script hash")
 	}
 
-	storage.Put(ctx, common.OwnerKey, owner)
 	storage.Put(ctx, netmapContractKey, addrNetmap)
 	storage.Put(ctx, containerContractKey, addrContainer)
 
@@ -59,12 +53,10 @@ func _deploy(data interface{}, isUpdate bool) {
 }
 
 // Update method updates contract source code and manifest. Can be invoked
-// only by contract owner.
+// only by committee.
 func Update(script []byte, manifest []byte, data interface{}) {
-	ctx := storage.GetReadOnlyContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can update contract")
+	if !common.HasUpdateAccess() {
+		panic("only committee can update contract")
 	}
 
 	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -67,21 +67,14 @@ func _deploy(data interface{}, isUpdate bool) {
 
 	args := data.([]interface{})
 	notaryDisabled := args[0].(bool)
-	owner := args[1].(interop.Hash160)
-	addrBalance := args[2].(interop.Hash160)
-	addrContainer := args[3].(interop.Hash160)
-	keys := args[4].([]interop.PublicKey)
-	config := args[5].([][]byte)
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can reinitialize contract")
-	}
+	addrBalance := args[1].(interop.Hash160)
+	addrContainer := args[2].(interop.Hash160)
+	keys := args[3].([]interop.PublicKey)
+	config := args[4].([][]byte)
 
 	if len(addrBalance) != 20 || len(addrContainer) != 20 {
 		panic("init: incorrect length of contract script hash")
 	}
-
-	storage.Put(ctx, common.OwnerKey, owner)
 
 	// epoch number is a little endian int, it doesn't need to be serialized
 	storage.Put(ctx, snapshotEpoch, 0)
@@ -124,12 +117,10 @@ func _deploy(data interface{}, isUpdate bool) {
 }
 
 // Update method updates contract source code and manifest. Can be invoked
-// only by contract owner.
+// only by committee.
 func Update(script []byte, manifest []byte, data interface{}) {
-	ctx := storage.GetReadOnlyContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can update contract")
+	if !common.HasUpdateAccess() {
+		panic("only committee can update contract")
 	}
 
 	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)

--- a/proxy/proxy_contract.go
+++ b/proxy/proxy_contract.go
@@ -29,32 +29,24 @@ func _deploy(data interface{}, isUpdate bool) {
 	}
 
 	args := data.([]interface{})
-	owner := args[0].(interop.Hash160)
-	addrNetmap := args[1].(interop.Hash160)
+	addrNetmap := args[0].(interop.Hash160)
 
 	ctx := storage.GetContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can reinitialize contract")
-	}
 
 	if len(addrNetmap) != 20 {
 		panic("init: incorrect length of contract script hash")
 	}
 
-	storage.Put(ctx, common.OwnerKey, owner)
 	storage.Put(ctx, netmapContractKey, addrNetmap)
 
 	runtime.Log("proxy contract initialized")
 }
 
 // Update method updates contract source code and manifest. Can be invoked
-// only by contract owner.
+// only by committee.
 func Update(script []byte, manifest []byte, data interface{}) {
-	ctx := storage.GetReadOnlyContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can update contract")
+	if !common.HasUpdateAccess() {
+		panic("only committee can update contract")
 	}
 
 	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)

--- a/reputation/reputation_contract.go
+++ b/reputation/reputation_contract.go
@@ -22,15 +22,8 @@ func _deploy(data interface{}, isUpdate bool) {
 
 	args := data.([]interface{})
 	notaryDisabled := args[0].(bool)
-	owner := args[1].(interop.Hash160)
 
 	ctx := storage.GetContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can reinitialize contract")
-	}
-
-	storage.Put(ctx, common.OwnerKey, owner)
 
 	// initialize the way to collect signatures
 	storage.Put(ctx, notaryDisabledKey, notaryDisabled)
@@ -43,12 +36,10 @@ func _deploy(data interface{}, isUpdate bool) {
 }
 
 // Update method updates contract source code and manifest. Can be invoked
-// only by contract owner.
+// only by committee.
 func Update(script []byte, manifest []byte, data interface{}) {
-	ctx := storage.GetReadOnlyContext()
-
-	if !common.HasUpdateAccess(ctx) {
-		panic("only owner can update contract")
+	if !common.HasUpdateAccess() {
+		panic("only committee can update contract")
 	}
 
 	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
@@ -136,7 +127,6 @@ func ListByEpoch(epoch int) [][]byte {
 	var result [][]byte
 
 	ignore := [][]byte{
-		[]byte(common.OwnerKey),
 		[]byte(notaryDisabledKey),
 	}
 


### PR DESCRIPTION
Do not save contract owner at the contract deploy stage. Use side chain committee witness to migrate contracts.
Close #107 