### PR TITLE
Rename migrate methods to update

### DIFF
--- a/alphabet/alphabet_contract.go
+++ b/alphabet/alphabet_contract.go
@@ -73,9 +73,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log(name + " contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {

--- a/audit/audit_contract.go
+++ b/audit/audit_contract.go
@@ -73,9 +73,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log("audit contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {

--- a/balance/balance_contract.go
+++ b/balance/balance_contract.go
@@ -93,9 +93,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log("balance contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -98,9 +98,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log("container contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {

--- a/neofs/neofs_contract.go
+++ b/neofs/neofs_contract.go
@@ -109,9 +109,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log("neofs: contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {

--- a/neofsid/neofsid_contract.go
+++ b/neofsid/neofsid_contract.go
@@ -58,9 +58,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log("neofsid contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -123,9 +123,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log("netmap contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {

--- a/processing/processing_contract.go
+++ b/processing/processing_contract.go
@@ -49,9 +49,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log("processing contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {

--- a/proxy/proxy_contract.go
+++ b/proxy/proxy_contract.go
@@ -48,9 +48,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log("proxy contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {

--- a/reputation/reputation_contract.go
+++ b/reputation/reputation_contract.go
@@ -42,9 +42,9 @@ func _deploy(data interface{}, isUpdate bool) {
 	runtime.Log("reputation contract initialized")
 }
 
-// Migrate method updates contract source code and manifest. Can be invoked
+// Update method updates contract source code and manifest. Can be invoked
 // only by contract owner.
-func Migrate(script []byte, manifest []byte, data interface{}) bool {
+func Update(script []byte, manifest []byte, data interface{}) bool {
 	ctx := storage.GetReadOnlyContext()
 
 	if !common.HasUpdateAccess(ctx) {


### PR DESCRIPTION
Neo Legacy used migration mechanism to update contracts. N3 provides update method in native management contract. Therefore, it makes sense to rename `Migrate` to `Update`.

Closes #128 