### PR TITLE
Register nice names for new containers

### DIFF
--- a/container/config.yml
+++ b/container/config.yml
@@ -1,7 +1,8 @@
 name: "NeoFS Container"
 safemethods: ["get", "owner", "list", "eACL", "getContainerSize", "listContainerSizes", "version"]
 permissions:
-  - methods: ["update", "addKey", "transferX"]
+  - methods: ["update", "addKey", "transferX",
+               "addRoot", "register", "addRecord"]
 events:
   - name: containerPut
     parameters:

--- a/container/config.yml
+++ b/container/config.yml
@@ -2,7 +2,7 @@ name: "NeoFS Container"
 safemethods: ["get", "owner", "list", "eACL", "getContainerSize", "listContainerSizes", "version"]
 permissions:
   - methods: ["update", "addKey", "transferX",
-               "addRoot", "register", "addRecord"]
+               "addRoot", "register", "addRecord", "deleteRecords"]
 events:
   - name: containerPut
     parameters:

--- a/nns/config.yml
+++ b/nns/config.yml
@@ -1,7 +1,7 @@
 name: "NameService"
 supportedstandards: ["NEP-11"]
 safemethods: ["balanceOf", "decimals", "symbol", "totalSupply", "tokensOf", "ownerOf",
-              "tokens", "properties", "roots", "getPrice", "isAvailable", "getRecord", "resolve"]
+              "tokens", "properties", "roots", "getPrice", "isAvailable", "getRecords", "resolve"]
 events:
   - name: Transfer
     parameters:

--- a/tests/balance_test.go
+++ b/tests/balance_test.go
@@ -1,0 +1,18 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/core"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+const balancePath = "../balance"
+
+func deployBalanceContract(t *testing.T, bc *core.Blockchain, addrNetmap, addrContainer util.Uint160) util.Uint160 {
+	args := make([]interface{}, 3)
+	args[0] = false
+	args[1] = addrNetmap
+	args[2] = addrContainer
+	return DeployContract(t, bc, balancePath, args)
+}

--- a/tests/basic.go
+++ b/tests/basic.go
@@ -174,7 +174,10 @@ func newDeployTx(t *testing.T, bc *core.Blockchain, ctrPath string, data interfa
 	tx := transaction.New(buf.Bytes(), 100*native.GASFactor)
 	tx.Nonce = nonce()
 	tx.ValidUntilBlock = bc.BlockHeight() + 1
-	tx.Signers = []transaction.Signer{{Account: CommitteeAcc.Contract.ScriptHash()}}
+	tx.Signers = []transaction.Signer{{
+		Account: CommitteeAcc.Contract.ScriptHash(),
+		Scopes:  transaction.Global,
+	}}
 	require.NoError(t, addNetworkFee(bc, tx, CommitteeAcc))
 	require.NoError(t, CommitteeAcc.SignTx(netmode.UnitTestNet, tx))
 	return tx, c.Hash

--- a/tests/compile.go
+++ b/tests/compile.go
@@ -1,0 +1,69 @@
+package tests
+
+import (
+	"path"
+
+	"github.com/nspcc-dev/neo-go/cli/smartcontract"
+	"github.com/nspcc-dev/neo-go/pkg/compiler"
+	"github.com/nspcc-dev/neo-go/pkg/config"
+	"github.com/nspcc-dev/neo-go/pkg/core/state"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/manifest"
+	"github.com/nspcc-dev/neo-go/pkg/smartcontract/nef"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+// Contract contains contract info for deployment.
+type Contract struct {
+	Hash     util.Uint160
+	NEF      *nef.File
+	Manifest *manifest.Manifest
+}
+
+var contracts = map[string]*Contract{}
+
+// ContractInfo compiles contract and returns it's NEF, manifest and hash.
+func ContractInfo(sender util.Uint160, ctrPath string) (*Contract, error) {
+	if c, ok := contracts[ctrPath]; ok {
+		return c, nil
+	}
+
+	// nef.NewFile() cares about version a lot.
+	config.Version = "0.90.0-test"
+
+	avm, di, err := compiler.CompileWithDebugInfo(ctrPath, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ne, err := nef.NewFile(avm)
+	if err != nil {
+		return nil, err
+	}
+
+	conf, err := smartcontract.ParseContractConfig(path.Join(ctrPath, "config.yml"))
+	if err != nil {
+		return nil, err
+	}
+
+	o := &compiler.Options{}
+	o.Name = conf.Name
+	o.ContractEvents = conf.Events
+	o.ContractSupportedStandards = conf.SupportedStandards
+	o.Permissions = make([]manifest.Permission, len(conf.Permissions))
+	for i := range conf.Permissions {
+		o.Permissions[i] = manifest.Permission(conf.Permissions[i])
+	}
+	o.SafeMethods = conf.SafeMethods
+	m, err := compiler.CreateManifest(di, o)
+	if err != nil {
+		return nil, err
+	}
+
+	c := &Contract{
+		Hash:     state.CreateContractHash(sender, ne.Checksum, m.Name),
+		NEF:      ne,
+		Manifest: m,
+	}
+	contracts[ctrPath] = c
+	return c, nil
+}

--- a/tests/container_test.go
+++ b/tests/container_test.go
@@ -1,0 +1,102 @@
+package tests
+
+import (
+	"crypto/sha256"
+	"testing"
+
+	"github.com/mr-tron/base58"
+	"github.com/nspcc-dev/neo-go/pkg/core"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
+	"github.com/nspcc-dev/neo-go/pkg/wallet"
+	"github.com/nspcc-dev/neofs-contract/nns"
+	"github.com/stretchr/testify/require"
+)
+
+const containerPath = "../container"
+
+func deployContainerContract(t *testing.T, bc *core.Blockchain, addrNetmap, addrBalance, addrNNS util.Uint160) util.Uint160 {
+	args := make([]interface{}, 6)
+	args[0] = int64(0)
+	args[1] = addrNetmap
+	args[2] = addrBalance
+	args[3] = util.Uint160{} // not needed for now
+	args[4] = addrNNS
+	args[5] = "neofs"
+	return DeployContract(t, bc, containerPath, args)
+}
+
+func prepareContainerContract(t *testing.T, bc *core.Blockchain) util.Uint160 {
+	addrNNS := DeployContract(t, bc, nnsPath, nil)
+
+	ctrNetmap, err := ContractInfo(CommitteeAcc.Contract.ScriptHash(), netmapPath)
+	require.NoError(t, err)
+
+	ctrBalance, err := ContractInfo(CommitteeAcc.Contract.ScriptHash(), balancePath)
+	require.NoError(t, err)
+
+	ctrContainer, err := ContractInfo(CommitteeAcc.Contract.ScriptHash(), containerPath)
+	require.NoError(t, err)
+
+	deployNetmapContract(t, bc, ctrBalance.Hash, ctrContainer.Hash, "ContainerFee", []byte{})
+	deployBalanceContract(t, bc, ctrNetmap.Hash, ctrContainer.Hash)
+	return deployContainerContract(t, bc, ctrNetmap.Hash, ctrBalance.Hash, addrNNS)
+}
+
+func setContainerOwner(c []byte, owner *wallet.Account) {
+	copy(c[7:], owner.Contract.ScriptHash().BytesBE())
+}
+
+func TestContainerPut(t *testing.T) {
+	bc := NewChain(t)
+	h := prepareContainerContract(t, bc)
+
+	acc := NewAccount(t, bc)
+	dummySig := make([]byte, 64)
+	dummyPub := make([]byte, 33)
+	dummyToken := make([]byte, 100)
+	container := make([]byte, 100)
+	setContainerOwner(container, acc)
+	containerID := sha256.Sum256(container)
+
+	tx := PrepareInvoke(t, bc, CommitteeAcc, h, "put", container, dummySig, dummyPub, dummyToken)
+	AddBlockCheckHalt(t, bc, tx)
+
+	t.Run("with nice names", func(t *testing.T) {
+		nnsHash := contracts[nnsPath].Hash
+
+		tx = PrepareInvoke(t, bc, CommitteeAcc, h, "putNamed",
+			container, dummySig, dummyPub, dummyToken, "mycnt", "")
+		AddBlockCheckHalt(t, bc, tx)
+
+		tx = PrepareInvoke(t, bc, CommitteeAcc, nnsHash, "resolve", "mycnt.neofs", int64(nns.TXT))
+		CheckTestInvoke(t, bc, tx, stackitem.NewArray([]stackitem.Item{
+			stackitem.NewByteArray([]byte(base58.Encode(containerID[:]))),
+		}))
+
+		tx = PrepareInvoke(t, bc, CommitteeAcc, h, "delete", containerID[:], dummySig, dummyToken)
+		AddBlockCheckHalt(t, bc, tx)
+
+		tx = PrepareInvoke(t, bc, CommitteeAcc, nnsHash, "resolve", "mycnt.neofs", int64(nns.TXT))
+		CheckTestInvoke(t, bc, tx, stackitem.Null{})
+
+		t.Run("register in advance", func(t *testing.T) {
+			container[len(container)-1] = 10
+			containerID = sha256.Sum256(container)
+
+			tx = PrepareInvoke(t, bc, []*wallet.Account{CommitteeAcc, acc}, nnsHash, "register",
+				"second.neofs", acc.Contract.ScriptHash(),
+				"whateveriwant@world.com", int64(0), int64(0), int64(0), int64(0))
+			AddBlockCheckHalt(t, bc, tx)
+
+			tx = PrepareInvoke(t, bc, []*wallet.Account{CommitteeAcc, acc}, h, "putNamed",
+				container, dummySig, dummyPub, dummyToken, "second", "neofs")
+			AddBlockCheckHalt(t, bc, tx)
+
+			tx = PrepareInvoke(t, bc, CommitteeAcc, nnsHash, "resolve", "second.neofs", int64(nns.TXT))
+			CheckTestInvoke(t, bc, tx, stackitem.NewArray([]stackitem.Item{
+				stackitem.NewByteArray([]byte(base58.Encode(containerID[:]))),
+			}))
+		})
+	})
+}

--- a/tests/netmap_test.go
+++ b/tests/netmap_test.go
@@ -1,0 +1,20 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/core"
+	"github.com/nspcc-dev/neo-go/pkg/util"
+)
+
+const netmapPath = "../netmap"
+
+func deployNetmapContract(t *testing.T, bc *core.Blockchain, addrBalance, addrContainer util.Uint160, config ...interface{}) util.Uint160 {
+	args := make([]interface{}, 5)
+	args[0] = false
+	args[1] = addrBalance
+	args[2] = addrContainer
+	args[3] = []interface{}{CommitteeAcc.PrivateKey().PublicKey().Bytes()}
+	args[4] = append([]interface{}{}, config...)
+	return DeployContract(t, bc, netmapPath, args)
+}


### PR DESCRIPTION
Close #134 .

Adressing some issues:
1. Container contract is the owner of all domains.
2. Renewing can be done via direct invocation of NNS contract. Currently there is no owner check, so anyone (alphabet) can pay GAS to renew domain.
3. Cybersquatting is possible, because anyone can register a domain. One way to prevent this is to allow registering "restricted" roots which need a committee signature to register domains in.