### PR TITLE
reputation: fix safe method names

### DIFF
--- a/reputation/config.yml
+++ b/reputation/config.yml
@@ -1,5 +1,5 @@
 name: "NeoFS Reputation"
-safemethods: ["get, getByID, listByEpoch"]
+safemethods: ["get", "getByID", "listByEpoch"]
 permissions:
   - methods: ["update"]
 events:


### PR DESCRIPTION
Also make it possible to compile with the latest neo-go version.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>