### PR TITLE
Fix notary-enabled logic in netmap contract

### DIFF
--- a/tests/netmap_test.go
+++ b/tests/netmap_test.go
@@ -96,3 +96,36 @@ func TestAddPeer(t *testing.T) {
 	require.Equal(t, 1, len(nodes))
 	checkNode(t, dummyInfo, 1, nodes[0])
 }
+
+func TestUpdateState(t *testing.T) {
+	bc := NewChain(t)
+	h := prepareNetmapContract(t, bc)
+
+	acc := NewAccount(t, bc)
+	dummyInfo := dummyNodeInfo(acc)
+
+	tx := PrepareInvoke(t, bc, []*wallet.Account{CommitteeAcc, acc}, h, "addPeer", dummyInfo)
+	AddBlockCheckHalt(t, bc, tx)
+
+	t.Run("missing witness", func(t *testing.T) {
+		tx = PrepareInvoke(t, bc, acc, h, "updateState", int64(2), acc.PrivateKey().PublicKey().Bytes())
+		AddBlock(t, bc, tx)
+		CheckFault(t, bc, tx.Hash(), "updateState: alphabet witness check failed")
+
+		tx = PrepareInvoke(t, bc, CommitteeAcc, h, "updateState", int64(2), acc.PrivateKey().PublicKey().Bytes())
+		AddBlock(t, bc, tx)
+		CheckFault(t, bc, tx.Hash(), "updateState: witness check failed")
+	})
+
+	tx = PrepareInvoke(t, bc, []*wallet.Account{CommitteeAcc, acc}, h,
+		"updateState", int64(2), acc.PrivateKey().PublicKey().Bytes())
+	AddBlockCheckHalt(t, bc, tx)
+
+	tx = PrepareInvoke(t, bc, acc, h, "netmapCandidates")
+	AddBlock(t, bc, tx)
+
+	aer := CheckHalt(t, bc, tx.Hash())
+	nodes, ok := aer.Stack[0].Value().([]stackitem.Item)
+	require.True(t, ok)
+	require.Equal(t, 0, len(nodes))
+}

--- a/tests/netmap_test.go
+++ b/tests/netmap_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"math/big"
 	"math/rand"
 	"testing"
 
@@ -54,27 +55,44 @@ func TestAddPeer(t *testing.T) {
 	acc := NewAccount(t, bc)
 	dummyInfo := dummyNodeInfo(acc)
 
-	acc1 := NewAccount(t, bc)
-	tx := PrepareInvoke(t, bc, acc1, h, "addPeer", dummyInfo)
+	tx := PrepareInvoke(t, bc, CommitteeAcc, h, "addPeer", dummyInfo)
 	AddBlock(t, bc, tx)
-	CheckFault(t, bc, tx.Hash(), "witness check failed")
+	CheckFault(t, bc, tx.Hash(), "addPeer: witness check failed")
 
 	tx = PrepareInvoke(t, bc, acc, h, "addPeer", dummyInfo)
 	AddBlock(t, bc, tx)
+	CheckFault(t, bc, tx.Hash(), "addPeer: alphabet witness check failed")
+
+	tx = PrepareInvoke(t, bc, []*wallet.Account{CommitteeAcc, acc}, h, "addPeer", dummyInfo)
+	AddBlockCheckHalt(t, bc, tx)
+
+	tx = PrepareInvoke(t, bc, acc, h, "netmapCandidates")
+	AddBlock(t, bc, tx)
+
+	checkNode := func(t *testing.T, info []byte, state int64, actual stackitem.Item) {
+		// Actual is netmap.netmapNode.
+		require.Equal(t, stackitem.NewStruct([]stackitem.Item{
+			stackitem.NewStruct([]stackitem.Item{
+				stackitem.NewByteArray(dummyInfo),
+			}),
+			stackitem.NewBigInteger(big.NewInt(state)),
+		}), actual)
+	}
 
 	aer := CheckHalt(t, bc, tx.Hash())
-	require.Equal(t, 1, len(aer.Events))
-	require.Equal(t, "AddPeer", aer.Events[0].Name)
-	require.Equal(t, stackitem.NewArray([]stackitem.Item{stackitem.NewByteArray(dummyInfo)}),
-		aer.Events[0].Item)
+	nodes, _ := aer.Stack[0].Value().([]stackitem.Item)
+	require.Equal(t, 1, len(nodes))
+	checkNode(t, dummyInfo, 1, nodes[0])
 
 	dummyInfo[0] ^= 0xFF
-	tx = PrepareInvoke(t, bc, acc, h, "addPeer", dummyInfo)
+	tx = PrepareInvoke(t, bc, []*wallet.Account{CommitteeAcc, acc}, h, "addPeer", dummyInfo)
+	AddBlockCheckHalt(t, bc, tx)
+
+	tx = PrepareInvoke(t, bc, acc, h, "netmapCandidates")
 	AddBlock(t, bc, tx)
 
 	aer = CheckHalt(t, bc, tx.Hash())
-	require.Equal(t, 1, len(aer.Events))
-	require.Equal(t, "AddPeer", aer.Events[0].Name)
-	require.Equal(t, stackitem.NewArray([]stackitem.Item{stackitem.NewByteArray(dummyInfo)}),
-		aer.Events[0].Item)
+	nodes, _ = aer.Stack[0].Value().([]stackitem.Item)
+	require.Equal(t, 1, len(nodes))
+	checkNode(t, dummyInfo, 1, nodes[0])
 }


### PR DESCRIPTION
Only alphabet calls are allowed.

Depends on #147 (tests) .