### PR TITLE
nns: fail if previous version is incorrect

### DIFF
--- a/alphabet/alphabet_contract.go
+++ b/alphabet/alphabet_contract.go
@@ -74,7 +74,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("alphabet contract updated")
 }
 

--- a/audit/audit_contract.go
+++ b/audit/audit_contract.go
@@ -74,7 +74,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("audit contract updated")
 }
 

--- a/balance/balance_contract.go
+++ b/balance/balance_contract.go
@@ -94,7 +94,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("balance contract updated")
 }
 

--- a/common/version.go
+++ b/common/version.go
@@ -1,9 +1,46 @@
 package common
 
+import "github.com/nspcc-dev/neo-go/pkg/interop/native/std"
+
 const (
 	major = 0
-	minor = 12
-	patch = 1
+	minor = 13
+	patch = 0
+
+	// Versions from which an update should be performed.
+	// These should be used in a group (so prevMinor can be equal to minor if there are
+	// any migration routines.
+	prevMajor = 0
+	prevMinor = 12
+	prevPatch = 0
 
 	Version = major*1_000_000 + minor*1_000 + patch
+
+	PrevVersion = prevMajor*1_000_000 + prevMinor*1_000 + prevPatch
+
+	// ErrVersionMismatch is thrown by CheckVersion in case of error.
+	ErrVersionMismatch = "previous version mismatch"
+
+	// ErrAlreadyUpdated is thrown by CheckVersion if current version equals to version contract
+	// is being updated from.
+	ErrAlreadyUpdated = "contract is already of the latest version"
 )
+
+// CheckVersion checks that previous version is more than PrevVersion to ensure migrating contract data
+// was done successfully.
+func CheckVersion(from int) {
+	if from < PrevVersion {
+		panic(ErrVersionMismatch + ": expected >=" + std.Itoa(PrevVersion, 10))
+	}
+	if from == Version {
+		panic(ErrAlreadyUpdated + ": " + std.Itoa(Version, 10))
+	}
+}
+
+// AppendVersion appends current contract version to the list of deploy arguments.
+func AppendVersion(data interface{}) []interface{} {
+	if data == nil {
+		return []interface{}{Version}
+	}
+	return append(data.([]interface{}), Version)
+}

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -141,7 +141,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("container contract updated")
 }
 

--- a/neofs/neofs_contract.go
+++ b/neofs/neofs_contract.go
@@ -116,7 +116,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only side chain committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("neofs contract updated")
 }
 

--- a/neofsid/neofsid_contract.go
+++ b/neofsid/neofsid_contract.go
@@ -59,7 +59,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("neofsid contract updated")
 }
 

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -123,7 +123,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("netmap contract updated")
 }
 

--- a/nns/nns_contract.go
+++ b/nns/nns_contract.go
@@ -83,7 +83,7 @@ func Update(nef []byte, manifest string) {
 	// thus we provide `AllowCall` to management.Update.
 	// management.Update(nef, []byte(manifest))
 	contract.Call(interop.Hash160(management.Hash), "update",
-		contract.All, nef, manifest)
+		contract.All, nef, manifest, common.AppendVersion(nil))
 }
 
 // _deploy initializes defaults (total supply and registration price) on contract deploy.

--- a/processing/processing_contract.go
+++ b/processing/processing_contract.go
@@ -56,7 +56,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only side chain committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("processing contract updated")
 }
 

--- a/proxy/proxy_contract.go
+++ b/proxy/proxy_contract.go
@@ -49,7 +49,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("proxy contract updated")
 }
 

--- a/reputation/reputation_contract.go
+++ b/reputation/reputation_contract.go
@@ -42,7 +42,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update",
+		contract.All, script, manifest, common.AppendVersion(data))
 	runtime.Log("reputation contract updated")
 }
 


### PR DESCRIPTION
We will need it also for #163 . I don't like the current interface (we need to append to args in `Update` if contract has any deploy-parameters), but at least it is something.
Related #158 .