### PR TITLE
nns: disallow record duplicates

### DIFF
--- a/nns/nns_contract.go
+++ b/nns/nns_contract.go
@@ -584,9 +584,14 @@ func addRecord(ctx storage.Context, tokenId []byte, name string, typ RecordType,
 	recordsKey := getRecordsKeyByType(tokenId, name, typ)
 
 	var id byte
-	records := storage.Find(ctx, recordsKey, storage.KeysOnly)
+	records := storage.Find(ctx, recordsKey, storage.ValuesOnly|storage.DeserializeValues)
 	for iterator.Next(records) {
 		id++
+
+		r := iterator.Value(records).(RecordState)
+		if r.Name == name && r.Type == typ && r.Data == data {
+			panic("record already exists")
+		}
 	}
 
 	if typ == CNAME && id != 0 {

--- a/tests/nns_test.go
+++ b/tests/nns_test.go
@@ -95,6 +95,8 @@ func TestNNSRegister(t *testing.T) {
 	cAcc := c.WithSigners(acc)
 	cAcc.Invoke(t, stackitem.Null{}, "addRecord",
 		"testdomain.com", int64(nns.TXT), "first TXT record")
+	cAcc.InvokeFail(t, "record already exists", "addRecord",
+		"testdomain.com", int64(nns.TXT), "first TXT record")
 	cAcc.Invoke(t, stackitem.Null{}, "addRecord",
 		"testdomain.com", int64(nns.TXT), "second TXT record")
 


### PR DESCRIPTION
Close #165 .
So we already iterate over records to checking for duplicates doesn't seem to introduce a big overhead.