### PR TITLE
Feat/Finish subnet contract

### DIFF
--- a/subnet/config.yml
+++ b/subnet/config.yml
@@ -5,8 +5,13 @@ permissions:
 events:
   - name: SubnetPut
     parameters:
+      - name: id
+        type: ByteArray
       - name: ownerKey
         type: PublicKey
       - name: info
         type: ByteArray
-
+  - name: SubnetDelete
+    parameters:
+        - name: id
+          type: ByteArray

--- a/subnet/config.yml
+++ b/subnet/config.yml
@@ -3,7 +3,7 @@ safemethods: ["version"]
 permissions:
   - methods: ["update"]
 events:
-  - name: SubnetPut
+  - name: Put
     parameters:
       - name: id
         type: ByteArray
@@ -11,11 +11,11 @@ events:
         type: PublicKey
       - name: info
         type: ByteArray
-  - name: SubnetDelete
+  - name: Delete
     parameters:
         - name: id
           type: ByteArray
-  - name: NodeRemove
+  - name: RemoveNode
     parameters:
         - name: subnetID
           type: ByteArray

--- a/subnet/config.yml
+++ b/subnet/config.yml
@@ -15,3 +15,9 @@ events:
     parameters:
         - name: id
           type: ByteArray
+  - name: NodeRemove
+    parameters:
+        - name: subnetID
+          type: ByteArray
+        - name: node
+          type: PublicKey

--- a/subnet/doc.go
+++ b/subnet/doc.go
@@ -1,0 +1,37 @@
+/*
+Subnet contract is a contract deployed in NeoFS side chain.
+
+Subnet contract stores and manages NeoFS subnetwork states. It allows registering
+and deleting subnetworks, limiting access to them and defining a list of the Storage
+Nodes that can be included in them.
+
+Contract notifications
+
+Put notification. This notification is produced when new subnetwork is
+registered by invoking Put method.
+
+  Put
+    - name: id
+      type: ByteArray
+    - name: ownerKey
+      type: PublicKey
+    - name: info
+      type: ByteArray
+
+Delete notification. This notification is produced when some subnetwork is
+deleted by invoking Delete method.
+
+  Delete
+    - name: id
+      type: ByteArray
+
+RemoveNode notification. This notification is produced when some node is deleted
+by invoking RemoveNode method.
+
+  RemoveNode
+    - name: subnetID
+      type: ByteArray
+    - name: node
+      type: PublicKey
+*/
+package subnet

--- a/subnet/subnet_contract.go
+++ b/subnet/subnet_contract.go
@@ -161,7 +161,7 @@ func Delete(id []byte) {
 	key := append([]byte{ownerPrefix}, id...)
 	raw := storage.Get(ctx, key)
 	if raw == nil {
-		panic("delete:" + ErrNotExist)
+		return
 	}
 
 	owner := raw.([]byte)
@@ -217,7 +217,7 @@ func AddNodeAdmin(subnetID []byte, adminKey interop.PublicKey) {
 	stKey[0] = nodeAdminPrefix
 
 	if keyInList(ctx, adminKey, stKey) {
-		panic("addNodeAdmin: node admin has already been added")
+		return
 	}
 
 	putKeyInList(ctx, adminKey, stKey)
@@ -252,7 +252,7 @@ func RemoveNodeAdmin(subnetID []byte, adminKey interop.PublicKey) {
 	stKey[0] = nodeAdminPrefix
 
 	if !keyInList(ctx, adminKey, stKey) {
-		panic("removeNodeAdmin: " + ErrNodeAdmNotExist)
+		return
 	}
 
 	deleteKeyFromList(ctx, adminKey, stKey)
@@ -291,7 +291,7 @@ func AddNode(subnetID []byte, node interop.PublicKey) {
 	stKey[0] = nodePrefix
 
 	if keyInList(ctx, node, stKey) {
-		panic("addNode: node has already been added")
+		return
 	}
 
 	putKeyInList(ctx, node, stKey)
@@ -330,7 +330,7 @@ func RemoveNode(subnetID []byte, node interop.PublicKey) {
 	stKey[0] = nodePrefix
 
 	if !keyInList(ctx, node, stKey) {
-		panic("removeNode: " + ErrNodeNotExist)
+		return
 	}
 
 	storage.Delete(ctx, append(stKey, node...))
@@ -399,7 +399,7 @@ func AddClientAdmin(subnetID []byte, groupID []byte, adminPublicKey interop.Publ
 	stKey = append(stKey, groupID...)
 
 	if keyInList(ctx, adminPublicKey, stKey) {
-		panic("addClientAdmin: client admin has already been added")
+		return
 	}
 
 	putKeyInList(ctx, adminPublicKey, stKey)
@@ -441,7 +441,7 @@ func RemoveClientAdmin(subnetID []byte, groupID []byte, adminPublicKey interop.P
 	stKey = append(stKey, groupID...)
 
 	if !keyInList(ctx, adminPublicKey, stKey) {
-		panic("removeClientAdmin: " + ErrClientAdmNotExist)
+		return
 	}
 
 	deleteKeyFromList(ctx, adminPublicKey, stKey)
@@ -486,7 +486,7 @@ func AddUser(subnetID []byte, groupID []byte, userID []byte) {
 	stKey[0] = userPrefix
 
 	if keyInList(ctx, userID, stKey) {
-		panic("addUser: user has already been added")
+		return
 	}
 
 	putKeyInList(ctx, userID, stKey)
@@ -531,7 +531,7 @@ func RemoveUser(subnetID []byte, groupID []byte, userID []byte) {
 	stKey[0] = userPrefix
 
 	if !keyInList(ctx, userID, stKey) {
-		panic("removeUser: " + ErrUserNotExist)
+		return
 	}
 
 	deleteKeyFromList(ctx, userID, stKey)

--- a/subnet/subnet_contract.go
+++ b/subnet/subnet_contract.go
@@ -11,8 +11,10 @@ import (
 )
 
 const (
-	// ErrInvalidSubnetID is thrown when subnet id is not a slice of 4 bytes.
+	// ErrInvalidSubnetID is thrown when subnet id is not a slice of 5 bytes.
 	ErrInvalidSubnetID = "invalid subnet ID"
+	// ErrInvalidGroupID is thrown when group id is not a slice of 5 bytes.
+	ErrInvalidGroupID = "invalid group ID"
 	// ErrInvalidOwner is thrown when owner has invalid format.
 	ErrInvalidOwner = "invalid owner"
 	// ErrInvalidAdmin is thrown when admin has invalid format.
@@ -134,6 +136,11 @@ func Put(id []byte, ownerKey interop.PublicKey, info []byte) {
 
 // Get returns info about subnet with the specified id.
 func Get(id []byte) []byte {
+	// V2 format check
+	if len(id) != subnetIDSize {
+		panic("get: " + ErrInvalidSubnetID)
+	}
+
 	ctx := storage.GetReadOnlyContext()
 	key := append([]byte{infoPrefix}, id...)
 	raw := storage.Get(ctx, key)
@@ -145,6 +152,11 @@ func Get(id []byte) []byte {
 
 // Delete deletes subnet with the specified id.
 func Delete(id []byte) {
+	// V2 format check
+	if len(id) != subnetIDSize {
+		panic("delete: " + ErrInvalidSubnetID)
+	}
+
 	ctx := storage.GetContext()
 	key := append([]byte{ownerPrefix}, id...)
 	raw := storage.Get(ctx, key)
@@ -167,6 +179,11 @@ func Delete(id []byte) {
 
 // AddNodeAdmin adds new node administrator to the specified subnetwork.
 func AddNodeAdmin(subnetID []byte, adminKey interop.PublicKey) {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("addNodeAdmin: " + ErrInvalidSubnetID)
+	}
+
 	if len(adminKey) != interop.PublicKeyCompressedLen {
 		panic("addNodeAdmin: " + ErrInvalidAdmin)
 	}
@@ -197,6 +214,11 @@ func AddNodeAdmin(subnetID []byte, adminKey interop.PublicKey) {
 // RemoveNodeAdmin removes node administrator from the specified subnetwork.
 // Must be called by subnet owner only.
 func RemoveNodeAdmin(subnetID []byte, adminKey interop.PublicKey) {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("removeNodeAdmin: " + ErrInvalidSubnetID)
+	}
+
 	if len(adminKey) != interop.PublicKeyCompressedLen {
 		panic("removeNodeAdmin: " + ErrInvalidAdmin)
 	}
@@ -228,6 +250,11 @@ func RemoveNodeAdmin(subnetID []byte, adminKey interop.PublicKey) {
 // Must be called by subnet's owner or node administrator
 // only.
 func AddNode(subnetID []byte, node interop.PublicKey) {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("addNode: " + ErrInvalidSubnetID)
+	}
+
 	if len(node) != interop.PublicKeyCompressedLen {
 		panic("addNode: " + ErrInvalidNode)
 	}
@@ -262,6 +289,11 @@ func AddNode(subnetID []byte, node interop.PublicKey) {
 // Must be called by subnet's owner or node administrator
 // only.
 func RemoveNode(subnetID []byte, node interop.PublicKey) {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("removeNode: " + ErrInvalidSubnetID)
+	}
+
 	if len(node) != interop.PublicKeyCompressedLen {
 		panic("removeNode: " + ErrInvalidNode)
 	}
@@ -297,6 +329,11 @@ func RemoveNode(subnetID []byte, node interop.PublicKey) {
 // NodeAllowed checks if node is included in the
 // specified subnet or not.
 func NodeAllowed(subnetID []byte, node interop.PublicKey) bool {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("nodeAllowed: " + ErrInvalidSubnetID)
+	}
+
 	if len(node) != interop.PublicKeyCompressedLen {
 		panic("nodeAllowed: " + ErrInvalidNode)
 	}
@@ -318,6 +355,16 @@ func NodeAllowed(subnetID []byte, node interop.PublicKey) bool {
 // AddClientAdmin adds new client administrator of the specified group in the specified subnetwork.
 // Must be called by owner only.
 func AddClientAdmin(subnetID []byte, groupID []byte, adminPublicKey interop.PublicKey) {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("addClientAdmin: " + ErrInvalidSubnetID)
+	}
+
+	// V2 format check
+	if len(groupID) != groupIDSize {
+		panic("addClientAdmin: " + ErrInvalidGroupID)
+	}
+
 	if len(adminPublicKey) != interop.PublicKeyCompressedLen {
 		panic("addClientAdmin: " + ErrInvalidAdmin)
 	}
@@ -350,6 +397,16 @@ func AddClientAdmin(subnetID []byte, groupID []byte, adminPublicKey interop.Publ
 // specified group in the specified subnetwork.
 // Must be called by owner only.
 func RemoveClientAdmin(subnetID []byte, groupID []byte, adminPublicKey interop.PublicKey) {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("removeClientAdmin: " + ErrInvalidSubnetID)
+	}
+
+	// V2 format check
+	if len(groupID) != groupIDSize {
+		panic("removeClientAdmin: " + ErrInvalidGroupID)
+	}
+
 	if len(adminPublicKey) != interop.PublicKeyCompressedLen {
 		panic("removeClientAdmin: " + ErrInvalidAdmin)
 	}
@@ -381,8 +438,19 @@ func RemoveClientAdmin(subnetID []byte, groupID []byte, adminPublicKey interop.P
 // AddUser adds user to the specified subnetwork and group.
 // Must be called by the owner or the group's admin only.
 func AddUser(subnetID []byte, groupID []byte, userID []byte) {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("addUser: " + ErrInvalidSubnetID)
+	}
+
+	// V2 format check
 	if len(userID) != userIDSize {
 		panic("addUser: " + ErrInvalidUser)
+	}
+
+	// V2 format check
+	if len(groupID) != groupIDSize {
+		panic("addUser: " + ErrInvalidGroupID)
 	}
 
 	ctx := storage.GetContext()
@@ -415,6 +483,16 @@ func AddUser(subnetID []byte, groupID []byte, userID []byte) {
 // RemoveUser removes user from the specified subnetwork and group.
 // Must be called by the owner or the group's admin only.
 func RemoveUser(subnetID []byte, groupID []byte, userID []byte) {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("removeUser: " + ErrInvalidSubnetID)
+	}
+
+	// V2 format check
+	if len(groupID) != groupIDSize {
+		panic("removeUser: " + ErrInvalidGroupID)
+	}
+
 	// V2 format check
 	if len(userID) != userIDSize {
 		panic("addUser: " + ErrInvalidUser)
@@ -450,6 +528,11 @@ func RemoveUser(subnetID []byte, groupID []byte, userID []byte) {
 // UserAllowed returns bool that indicates if node is included in the
 // specified subnet or not.
 func UserAllowed(subnetID []byte, user []byte) bool {
+	// V2 format check
+	if len(subnetID) != subnetIDSize {
+		panic("userAllowed: " + ErrInvalidSubnetID)
+	}
+
 	ctx := storage.GetContext()
 
 	stKey := append([]byte{ownerPrefix}, subnetID...)

--- a/subnet/subnet_contract.go
+++ b/subnet/subnet_contract.go
@@ -37,7 +37,9 @@ const (
 	ErrAccessDenied = "access denied"
 
 	errCheckWitnessFailed = "owner witness check failed"
+)
 
+const (
 	nodeAdminPrefix   = 'a'
 	infoPrefix        = 'i'
 	clientAdminPrefix = 'm'
@@ -49,6 +51,8 @@ const (
 
 const (
 	userIDSize = 27
+	subnetIDSize = 5
+	groupIDSize  = 5
 )
 
 // _deploy function sets up initial list of inner ring public keys.
@@ -78,7 +82,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 
 // Put creates new subnet with the specified owner and info.
 func Put(id []byte, ownerKey interop.PublicKey, info []byte) {
-	if len(id) != 4 {
+	// V2 format check
+	if len(id) != subnetIDSize {
 		panic("put: " + ErrInvalidSubnetID)
 	}
 	if len(ownerKey) != interop.PublicKeyCompressedLen {
@@ -441,8 +446,6 @@ func RemoveUser(subnetID []byte, groupID []byte, userID []byte) {
 
 	deleteKeyFromList(ctx, userID, stKey)
 }
-
-const groupIDSize = 4
 
 // UserAllowed returns bool that indicates if node is included in the
 // specified subnet or not.

--- a/subnet/subnet_contract.go
+++ b/subnet/subnet_contract.go
@@ -52,7 +52,7 @@ const (
 )
 
 const (
-	userIDSize = 27
+	userIDSize   = 27
 	subnetIDSize = 5
 	groupIDSize  = 5
 )
@@ -106,7 +106,7 @@ func Put(id []byte, ownerKey interop.PublicKey, info []byte) {
 			if !runtime.CheckWitness(ownerKey) {
 				panic("put: witness check failed")
 			}
-			runtime.Notify("SubnetPut", id, ownerKey, info)
+			runtime.Notify("Put", id, ownerKey, info)
 			return
 		}
 
@@ -174,7 +174,7 @@ func Delete(id []byte) {
 	key[0] = infoPrefix
 	storage.Delete(ctx, key)
 
-	runtime.Notify("SubnetDelete", id)
+	runtime.Notify("Delete", id)
 }
 
 // AddNodeAdmin adds new node administrator to the specified subnetwork.
@@ -323,7 +323,7 @@ func RemoveNode(subnetID []byte, node interop.PublicKey) {
 
 	storage.Delete(ctx, append(stKey, node...))
 
-	runtime.Notify("NodeRemove", subnetID, node)
+	runtime.Notify("RemoveNode", subnetID, node)
 }
 
 // NodeAllowed checks if node is included in the

--- a/subnet/subnet_contract.go
+++ b/subnet/subnet_contract.go
@@ -80,7 +80,7 @@ func Put(id []byte, ownerKey interop.PublicKey, info []byte) {
 			if !runtime.CheckWitness(ownerKey) {
 				panic("put: witness check failed")
 			}
-			runtime.Notify("SubnetPut", ownerKey, info)
+			runtime.Notify("SubnetPut", id, ownerKey, info)
 			return
 		}
 
@@ -137,6 +137,8 @@ func Delete(id []byte) {
 
 	key[0] = infoPrefix
 	storage.Delete(ctx, key)
+
+	runtime.Notify("SubnetDelete", id)
 }
 
 // AddNodeAdmin adds new node administrator to the specified subnetwork.

--- a/subnet/subnet_contract.go
+++ b/subnet/subnet_contract.go
@@ -174,6 +174,18 @@ func Delete(id []byte) {
 	key[0] = infoPrefix
 	storage.Delete(ctx, key)
 
+	key[0] = nodeAdminPrefix
+	deleteByPrefix(ctx, key)
+
+	key[0] = nodePrefix
+	deleteByPrefix(ctx, key)
+
+	key[0] = clientAdminPrefix
+	deleteByPrefix(ctx, key)
+
+	key[0] = userPrefix
+	deleteByPrefix(ctx, key)
+
 	runtime.Notify("Delete", id)
 }
 
@@ -569,6 +581,14 @@ func putKeyInList(ctx storage.Context, keyToPut interop.PublicKey, prefix []byte
 
 func deleteKeyFromList(ctx storage.Context, keyToDelete interop.PublicKey, prefix []byte) {
 	storage.Delete(ctx, append(prefix, keyToDelete...))
+}
+
+func deleteByPrefix(ctx storage.Context, prefix []byte) {
+	iter := storage.Find(ctx, prefix, storage.KeysOnly)
+	for iterator.Next(iter) {
+		k := iterator.Value(iter).([]byte)
+		storage.Delete(ctx, k)
+	}
 }
 
 func calledByOwnerOrAdmin(ctx storage.Context, owner []byte, adminPrefix []byte) bool {

--- a/subnet/subnet_contract.go
+++ b/subnet/subnet_contract.go
@@ -19,8 +19,8 @@ const (
 	ErrInvalidAdmin = "invalid administrator"
 	// ErrAlreadyExists is thrown when id already exists.
 	ErrAlreadyExists = "subnet id already exists"
-	// ErrSubNotExist is thrown when id doesn't exist.
-	ErrSubNotExist = "subnet id doesn't exist"
+	// ErrNotExist is thrown when id doesn't exist.
+	ErrNotExist = "subnet id doesn't exist"
 	// ErrInvalidUser is thrown when user has invalid format.
 	ErrInvalidUser = "invalid user"
 	// ErrInvalidNode is thrown when node has invalid format.
@@ -133,7 +133,7 @@ func Get(id []byte) []byte {
 	key := append([]byte{infoPrefix}, id...)
 	raw := storage.Get(ctx, key)
 	if raw == nil {
-		panic("get: " + ErrSubNotExist)
+		panic("get: " + ErrNotExist)
 	}
 	return raw.([]byte)
 }
@@ -144,7 +144,7 @@ func Delete(id []byte) {
 	key := append([]byte{ownerPrefix}, id...)
 	raw := storage.Get(ctx, key)
 	if raw == nil {
-		panic("delete:" + ErrSubNotExist)
+		panic("delete:" + ErrNotExist)
 	}
 
 	owner := raw.([]byte)
@@ -172,7 +172,7 @@ func AddNodeAdmin(subnetID []byte, adminKey interop.PublicKey) {
 
 	rawOwner := storage.Get(ctx, stKey)
 	if rawOwner == nil {
-		panic("addNodeAdmin: " + ErrSubNotExist)
+		panic("addNodeAdmin: " + ErrNotExist)
 	}
 
 	owner := rawOwner.([]byte)
@@ -202,7 +202,7 @@ func RemoveNodeAdmin(subnetID []byte, adminKey interop.PublicKey) {
 
 	rawOwner := storage.Get(ctx, stKey)
 	if rawOwner == nil {
-		panic("removeNodeAdmin: " + ErrSubNotExist)
+		panic("removeNodeAdmin: " + ErrNotExist)
 	}
 
 	owner := rawOwner.([]byte)
@@ -233,7 +233,7 @@ func AddNode(subnetID []byte, node interop.PublicKey) {
 
 	rawOwner := storage.Get(ctx, stKey)
 	if rawOwner == nil {
-		panic("addNode: " + ErrSubNotExist)
+		panic("addNode: " + ErrNotExist)
 	}
 
 	stKey[0] = nodeAdminPrefix
@@ -267,7 +267,7 @@ func RemoveNode(subnetID []byte, node interop.PublicKey) {
 
 	rawOwner := storage.Get(ctx, stKey)
 	if rawOwner == nil {
-		panic("removeNode: " + ErrSubNotExist)
+		panic("removeNode: " + ErrNotExist)
 	}
 
 	stKey[0] = nodeAdminPrefix
@@ -302,7 +302,7 @@ func NodeAllowed(subnetID []byte, node interop.PublicKey) bool {
 
 	rawOwner := storage.Get(ctx, stKey)
 	if rawOwner == nil {
-		panic("nodeAllowed: " + ErrSubNotExist)
+		panic("nodeAllowed: " + ErrNotExist)
 	}
 
 	stKey[0] = nodePrefix
@@ -323,7 +323,7 @@ func AddClientAdmin(subnetID []byte, groupID []byte, adminPublicKey interop.Publ
 
 	rawOwner := storage.Get(ctx, stKey)
 	if rawOwner == nil {
-		panic("addClientAdmin: " + ErrSubNotExist)
+		panic("addClientAdmin: " + ErrNotExist)
 	}
 
 	owner := rawOwner.([]byte)
@@ -355,7 +355,7 @@ func RemoveClientAdmin(subnetID []byte, groupID []byte, adminPublicKey interop.P
 
 	rawOwner := storage.Get(ctx, stKey)
 	if rawOwner == nil {
-		panic("removeClientAdmin: " + ErrSubNotExist)
+		panic("removeClientAdmin: " + ErrNotExist)
 	}
 
 	owner := rawOwner.([]byte)
@@ -386,7 +386,7 @@ func AddUser(subnetID []byte, groupID []byte, userID []byte) {
 
 	rawOwner := storage.Get(ctx, stKey)
 	if rawOwner == nil {
-		panic("addUser: " + ErrSubNotExist)
+		panic("addUser: " + ErrNotExist)
 	}
 
 	stKey[0] = clientAdminPrefix
@@ -421,7 +421,7 @@ func RemoveUser(subnetID []byte, groupID []byte, userID []byte) {
 
 	rawOwner := storage.Get(ctx, stKey)
 	if rawOwner == nil {
-		panic("removeUser: " + ErrSubNotExist)
+		panic("removeUser: " + ErrNotExist)
 	}
 
 	stKey[0] = clientAdminPrefix
@@ -451,7 +451,7 @@ func UserAllowed(subnetID []byte, user []byte) bool {
 
 	stKey := append([]byte{ownerPrefix}, subnetID...)
 	if storage.Get(ctx, stKey) == nil {
-		panic("userAllowed: " + ErrSubNotExist)
+		panic("userAllowed: " + ErrNotExist)
 	}
 
 	stKey[0] = userPrefix

--- a/subnet/subnet_contract.go
+++ b/subnet/subnet_contract.go
@@ -38,6 +38,17 @@ func _deploy(data interface{}, isUpdate bool) {
 	storage.Put(ctx, []byte{notaryDisabledKey}, args.notaryDisabled)
 }
 
+// Update method updates contract source code and manifest. Can be invoked
+// only by committee.
+func Update(script []byte, manifest []byte, data interface{}) {
+	if !common.HasUpdateAccess() {
+		panic("only committee can update contract")
+	}
+
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	runtime.Log("subnet contract updated")
+}
+
 // Put creates new subnet with the specified owner and info.
 func Put(id []byte, ownerKey interop.PublicKey, info []byte) {
 	if len(id) != 4 {
@@ -118,17 +129,6 @@ func Delete(id []byte) {
 
 	key[0] = infoPrefix
 	storage.Delete(ctx, key)
-}
-
-// Update method updates contract source code and manifest. Can be invoked
-// only by committee.
-func Update(script []byte, manifest []byte, data interface{}) {
-	if !common.HasUpdateAccess() {
-		panic("only committee can update contract")
-	}
-
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
-	runtime.Log("subnet contract updated")
 }
 
 // Version returns version of the contract.

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -67,10 +67,9 @@ func TestSubnet_Delete(t *testing.T) {
 
 	cAcc := e.WithSigners(owner)
 	cAcc.InvokeFail(t, subnet.ErrInvalidSubnetID, "delete", []byte{1, 1, 1, 1})
-	cAcc.InvokeFail(t, subnet.ErrNotExist, "delete", []byte{1, 1, 1, 1, 1})
+	cAcc.Invoke(t, stackitem.Null{}, "delete", []byte{1, 1, 1, 1, 1})
 	cAcc.Invoke(t, stackitem.Null{}, "delete", id)
 	cAcc.InvokeFail(t, subnet.ErrNotExist, "get", id)
-	cAcc.InvokeFail(t, subnet.ErrNotExist, "delete", id)
 }
 
 func TestSubnet_AddNodeAdmin(t *testing.T) {
@@ -94,7 +93,7 @@ func TestSubnet_AddNodeAdmin(t *testing.T) {
 	cOwner := e.WithSigners(owner)
 	cOwner.Invoke(t, stackitem.Null{}, method, id, admPub)
 
-	cOwner.InvokeFail(t, "node admin has already been added", method, id, admPub)
+	cOwner.Invoke(t, stackitem.Null{}, method, id, admPub)
 }
 
 func TestSubnet_RemoveNodeAdmin(t *testing.T) {
@@ -117,10 +116,10 @@ func TestSubnet_RemoveNodeAdmin(t *testing.T) {
 
 	cOwner := e.WithSigners(owner)
 
-	cOwner.InvokeFail(t, subnet.ErrNodeAdmNotExist, method, id, admPub)
+	cOwner.Invoke(t, stackitem.Null{}, method, id, admPub)
 	cOwner.Invoke(t, stackitem.Null{}, "addNodeAdmin", id, admPub)
 	cOwner.Invoke(t, stackitem.Null{}, method, id, admPub)
-	cOwner.InvokeFail(t, subnet.ErrNodeAdmNotExist, method, id, admPub)
+	cOwner.Invoke(t, stackitem.Null{}, method, id, admPub)
 }
 
 func TestSubnet_AddNode(t *testing.T) {
@@ -140,7 +139,7 @@ func TestSubnet_AddNode(t *testing.T) {
 	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
-	cOwn.InvokeFail(t, "node has already been added", method, id, nodePub)
+	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
 }
 
 func TestSubnet_RemoveNode(t *testing.T) {
@@ -162,7 +161,7 @@ func TestSubnet_RemoveNode(t *testing.T) {
 	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
 	cOwn.InvokeFail(t, subnet.ErrInvalidNode, method, id, nodePub[1:])
 	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
-	cOwn.InvokeFail(t, subnet.ErrNodeNotExist, method, id, nodePub)
+	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
@@ -170,7 +169,7 @@ func TestSubnet_RemoveNode(t *testing.T) {
 	cAdm := cOwn.WithSigners(adm)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNodeAdmin", id, admPub)
-	cAdm.InvokeFail(t, subnet.ErrNodeNotExist, method, id, nodePub)
+	cAdm.Invoke(t, stackitem.Null{}, method, id, nodePub)
 }
 
 func TestSubnet_NodeAllowed(t *testing.T) {
@@ -212,7 +211,7 @@ func TestSubnet_AddClientAdmin(t *testing.T) {
 	cOwn.InvokeFail(t, subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
 	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
-	cOwn.InvokeFail(t, "client admin has already been added", method, id, groupId, admPub)
+	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
 }
 
 func TestSubnet_RemoveClientAdmin(t *testing.T) {
@@ -232,7 +231,7 @@ func TestSubnet_RemoveClientAdmin(t *testing.T) {
 	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, admPub)
 	cOwn.InvokeFail(t, subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
 	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, admPub)
-	cOwn.InvokeFail(t, subnet.ErrClientAdmNotExist, method, id, groupId, admPub)
+	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
 }
@@ -260,7 +259,7 @@ func TestSubnet_AddUser(t *testing.T) {
 
 	cAdm := e.WithSigners(adm)
 	cAdm.Invoke(t, stackitem.Null{}, method, id, groupId, user)
-	cOwn.InvokeFail(t, "user has already been added", method, id, groupId, user)
+	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, user)
 }
 
 func TestSubnet_RemoveUser(t *testing.T) {
@@ -281,14 +280,14 @@ func TestSubnet_RemoveUser(t *testing.T) {
 	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, user)
 	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, user)
 
-	cOwn.InvokeFail(t, subnet.ErrUserNotExist, method, id, groupId, user)
+	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, user)
 	cOwn.Invoke(t, stackitem.Null{}, "addUser", id, groupId, user)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, user)
 
 	cAdm := cOwn.WithSigners(adm)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
-	cAdm.InvokeFail(t, subnet.ErrUserNotExist, method, id, groupId, user)
+	cAdm.Invoke(t, stackitem.Null{}, method, id, groupId, user)
 }
 
 func TestSubnet_UserAllowed(t *testing.T) {

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -124,6 +124,24 @@ func TestSubnet_RemoveNodeAdmin(t *testing.T) {
 	cOwner.InvokeFail(t, method+errSeparator+subnet.ErrNodeAdmNotExist, method, id, admPub)
 }
 
+func TestSubnet_AddNode(t *testing.T) {
+	e := newSubnetInvoker(t)
+
+	id, owner := createSubnet(t, e)
+
+	node := e.NewAccount(t)
+	nodePub, ok := vm.ParseSignatureContract(node.Script())
+	require.True(t, ok)
+
+	const method = "addNode"
+
+	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, nodePub[1:])
+
+	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
+	cOwn.InvokeFail(t, method+errSeparator+"node has already been added", method, id, nodePub)
+}
+
 func createSubnet(t *testing.T, e *neotest.ContractInvoker) (id []byte, owner neotest.Signer) {
 	var (
 		ok  bool

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -233,6 +233,31 @@ func TestSubnet_RemoveClientAdmin(t *testing.T) {
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
 }
 
+func TestSubnet_AddUser(t *testing.T) {
+	e := newSubnetInvoker(t)
+
+	id, owner := createSubnet(t, e)
+
+	adm := e.NewAccount(t)
+	admPub, ok := vm.ParseSignatureContract(adm.Script())
+	require.True(t, ok)
+
+	user := randomBytes(27)
+
+	groupId := randomBytes(8)
+
+	const method = "addUser"
+
+	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, groupId, user)
+
+	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
+
+	cAdm := e.WithSigners(adm)
+	cAdm.Invoke(t, stackitem.Null{}, method, id, groupId, user)
+	cOwn.InvokeFail(t, method+errSeparator+"user has already been added", method, id, groupId, user)
+}
+
 func createSubnet(t *testing.T, e *neotest.ContractInvoker) (id []byte, owner neotest.Signer) {
 	var (
 		ok  bool

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -212,6 +212,27 @@ func TestSubnet_AddClientAdmin(t *testing.T) {
 	cOwn.InvokeFail(t, method+errSeparator+"client admin has already been added", method, id, groupId, admPub)
 }
 
+func TestSubnet_RemoveClientAdmin(t *testing.T) {
+	e := newSubnetInvoker(t)
+
+	id, owner := createSubnet(t, e)
+
+	adm := e.NewAccount(t)
+	admPub, ok := vm.ParseSignatureContract(adm.Script())
+	require.True(t, ok)
+
+	const method = "removeClientAdmin"
+
+	groupId := randomBytes(8)
+
+	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, groupId, admPub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrClientAdmNotExist, method, id, groupId, admPub)
+	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
+	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
+}
+
 func createSubnet(t *testing.T, e *neotest.ContractInvoker) (id []byte, owner neotest.Signer) {
 	var (
 		ok  bool

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -285,6 +285,25 @@ func TestSubnet_RemoveUser(t *testing.T) {
 	cAdm.InvokeFail(t, method+errSeparator+subnet.ErrUserNotExist, method, id, groupId, user)
 }
 
+func TestSubnet_UserAllowed(t *testing.T) {
+	e := newSubnetInvoker(t)
+
+	id, owner := createSubnet(t, e)
+
+	groupId := randomBytes(4)
+
+	user := randomBytes(27)
+
+	const method = "userAllowed"
+
+	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, user)
+
+	cOwn.Invoke(t, stackitem.NewBool(false), method, id, user)
+	cOwn.Invoke(t, stackitem.Null{}, "addUser", id, groupId, user)
+	cOwn.Invoke(t, stackitem.NewBool(true), method, id, user)
+}
+
 func createSubnet(t *testing.T, e *neotest.ContractInvoker) (id []byte, owner neotest.Signer) {
 	var (
 		ok  bool

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -14,11 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-const (
-	subnetPath = "../subnet"
-
-	errSeparator = ": "
-)
+const subnetPath = "../subnet"
 
 func deploySubnetContract(t *testing.T, e *neotest.Executor) util.Uint160 {
 	c := neotest.CompileFile(t, e.CommitteeHash, subnetPath, path.Join(subnetPath, "config.yml"))
@@ -88,17 +84,17 @@ func TestSubnet_AddNodeAdmin(t *testing.T) {
 
 	const method = "addNodeAdmin"
 
-	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, admPub)
-	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, admPub[1:])
-	e.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, admPub)
+	e.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, admPub)
+	e.InvokeFail(t, subnet.ErrInvalidAdmin, method, id, admPub[1:])
+	e.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, admPub)
 
 	cAdm := e.WithSigners(adm)
-	cAdm.InvokeFail(t, method+errSeparator+"owner witness check failed", method, id, admPub)
+	cAdm.InvokeFail(t, "owner witness check failed", method, id, admPub)
 
 	cOwner := e.WithSigners(owner)
 	cOwner.Invoke(t, stackitem.Null{}, method, id, admPub)
 
-	cOwner.InvokeFail(t, method+errSeparator+"node admin has already been added", method, id, admPub)
+	cOwner.InvokeFail(t, "node admin has already been added", method, id, admPub)
 }
 
 func TestSubnet_RemoveNodeAdmin(t *testing.T) {
@@ -112,19 +108,19 @@ func TestSubnet_RemoveNodeAdmin(t *testing.T) {
 
 	const method = "removeNodeAdmin"
 
-	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, admPub)
-	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, admPub[1:])
-	e.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, admPub)
+	e.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, admPub)
+	e.InvokeFail(t, subnet.ErrInvalidAdmin, method, id, admPub[1:])
+	e.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, admPub)
 
 	cAdm := e.WithSigners(adm)
-	cAdm.InvokeFail(t, method+errSeparator+"owner witness check failed", method, id, admPub)
+	cAdm.InvokeFail(t, "owner witness check failed", method, id, admPub)
 
 	cOwner := e.WithSigners(owner)
 
-	cOwner.InvokeFail(t, method+errSeparator+subnet.ErrNodeAdmNotExist, method, id, admPub)
+	cOwner.InvokeFail(t, subnet.ErrNodeAdmNotExist, method, id, admPub)
 	cOwner.Invoke(t, stackitem.Null{}, "addNodeAdmin", id, admPub)
 	cOwner.Invoke(t, stackitem.Null{}, method, id, admPub)
-	cOwner.InvokeFail(t, method+errSeparator+subnet.ErrNodeAdmNotExist, method, id, admPub)
+	cOwner.InvokeFail(t, subnet.ErrNodeAdmNotExist, method, id, admPub)
 }
 
 func TestSubnet_AddNode(t *testing.T) {
@@ -139,12 +135,12 @@ func TestSubnet_AddNode(t *testing.T) {
 	const method = "addNode"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidNode, method, id, nodePub[1:])
+	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
-	cOwn.InvokeFail(t, method+errSeparator+"node has already been added", method, id, nodePub)
+	cOwn.InvokeFail(t, "node has already been added", method, id, nodePub)
 }
 
 func TestSubnet_RemoveNode(t *testing.T) {
@@ -163,10 +159,10 @@ func TestSubnet_RemoveNode(t *testing.T) {
 	const method = "removeNode"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNodeNotExist, method, id, nodePub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidNode, method, id, nodePub[1:])
+	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, subnet.ErrNodeNotExist, method, id, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
@@ -174,7 +170,7 @@ func TestSubnet_RemoveNode(t *testing.T) {
 	cAdm := cOwn.WithSigners(adm)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNodeAdmin", id, admPub)
-	cAdm.InvokeFail(t, method+errSeparator+subnet.ErrNodeNotExist, method, id, nodePub)
+	cAdm.InvokeFail(t, subnet.ErrNodeNotExist, method, id, nodePub)
 }
 
 func TestSubnet_NodeAllowed(t *testing.T) {
@@ -189,9 +185,9 @@ func TestSubnet_NodeAllowed(t *testing.T) {
 	const method = "nodeAllowed"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidNode, method, id, nodePub[1:])
+	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
 	cOwn.Invoke(t, stackitem.NewBool(false), method, id, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
@@ -212,11 +208,11 @@ func TestSubnet_AddClientAdmin(t *testing.T) {
 	groupId := randomBytes(5)
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, admPub)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, admPub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, admPub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
+	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
-	cOwn.InvokeFail(t, method+errSeparator+"client admin has already been added", method, id, groupId, admPub)
+	cOwn.InvokeFail(t, "client admin has already been added", method, id, groupId, admPub)
 }
 
 func TestSubnet_RemoveClientAdmin(t *testing.T) {
@@ -233,10 +229,10 @@ func TestSubnet_RemoveClientAdmin(t *testing.T) {
 	groupId := randomBytes(5)
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, admPub)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, admPub)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrClientAdmNotExist, method, id, groupId, admPub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, admPub)
+	cOwn.InvokeFail(t, subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
+	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, admPub)
+	cOwn.InvokeFail(t, subnet.ErrClientAdmNotExist, method, id, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
 }
@@ -257,14 +253,14 @@ func TestSubnet_AddUser(t *testing.T) {
 	const method = "addUser"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, user)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, user)
+	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, user)
+	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, user)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
 
 	cAdm := e.WithSigners(adm)
 	cAdm.Invoke(t, stackitem.Null{}, method, id, groupId, user)
-	cOwn.InvokeFail(t, method+errSeparator+"user has already been added", method, id, groupId, user)
+	cOwn.InvokeFail(t, "user has already been added", method, id, groupId, user)
 }
 
 func TestSubnet_RemoveUser(t *testing.T) {
@@ -282,17 +278,17 @@ func TestSubnet_RemoveUser(t *testing.T) {
 	const method = "removeUser"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, user)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, user)
+	cOwn.InvokeFail(t, subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, user)
+	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, user)
 
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrUserNotExist, method, id, groupId, user)
+	cOwn.InvokeFail(t, subnet.ErrUserNotExist, method, id, groupId, user)
 	cOwn.Invoke(t, stackitem.Null{}, "addUser", id, groupId, user)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, user)
 
 	cAdm := cOwn.WithSigners(adm)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
-	cAdm.InvokeFail(t, method+errSeparator+subnet.ErrUserNotExist, method, id, groupId, user)
+	cAdm.InvokeFail(t, subnet.ErrUserNotExist, method, id, groupId, user)
 }
 
 func TestSubnet_UserAllowed(t *testing.T) {
@@ -307,7 +303,7 @@ func TestSubnet_UserAllowed(t *testing.T) {
 	const method = "userAllowed"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, user)
+	cOwn.InvokeFail(t, subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, user)
 
 	cOwn.Invoke(t, stackitem.NewBool(false), method, id, user)
 	cOwn.Invoke(t, stackitem.Null{}, "addUser", id, groupId, user)

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -136,7 +136,7 @@ func TestSubnet_AddNode(t *testing.T) {
 	const method = "addNode"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, nodePub[1:])
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
 
 	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
 	cOwn.InvokeFail(t, method+errSeparator+"node has already been added", method, id, nodePub)
@@ -158,7 +158,7 @@ func TestSubnet_RemoveNode(t *testing.T) {
 	const method = "removeNode"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, nodePub[1:])
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNodeNotExist, method, id, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
@@ -168,6 +168,25 @@ func TestSubnet_RemoveNode(t *testing.T) {
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNodeAdmin", id, admPub)
 	cAdm.InvokeFail(t, method+errSeparator+subnet.ErrNodeNotExist, method, id, nodePub)
+}
+
+func TestSubnet_NodeAllowed(t *testing.T) {
+	e := newSubnetInvoker(t)
+
+	id, owner := createSubnet(t, e)
+
+	node := e.NewAccount(t)
+	nodePub, ok := vm.ParseSignatureContract(node.Script())
+	require.True(t, ok)
+
+	const method = "nodeAllowed"
+
+	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
+	cOwn.Invoke(t, stackitem.NewBool(false), method, id, nodePub)
+
+	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
+	cOwn.Invoke(t, stackitem.NewBool(true), method, id, nodePub)
 }
 
 func createSubnet(t *testing.T, e *neotest.ContractInvoker) (id []byte, owner neotest.Signer) {

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -142,6 +142,34 @@ func TestSubnet_AddNode(t *testing.T) {
 	cOwn.InvokeFail(t, method+errSeparator+"node has already been added", method, id, nodePub)
 }
 
+func TestSubnet_RemoveNode(t *testing.T) {
+	e := newSubnetInvoker(t)
+
+	id, owner := createSubnet(t, e)
+
+	node := e.NewAccount(t)
+	nodePub, ok := vm.ParseSignatureContract(node.Script())
+	require.True(t, ok)
+
+	adm := e.NewAccount(t)
+	admPub, ok := vm.ParseSignatureContract(adm.Script())
+	require.True(t, ok)
+
+	const method = "removeNode"
+
+	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, nodePub[1:])
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNodeNotExist, method, id, nodePub)
+
+	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
+	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
+
+	cAdm := cOwn.WithSigners(adm)
+
+	cOwn.Invoke(t, stackitem.Null{}, "addNodeAdmin", id, admPub)
+	cAdm.InvokeFail(t, method+errSeparator+subnet.ErrNodeNotExist, method, id, nodePub)
+}
+
 func createSubnet(t *testing.T, e *neotest.ContractInvoker) (id []byte, owner neotest.Signer) {
 	var (
 		ok  bool

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -209,7 +209,7 @@ func TestSubnet_AddClientAdmin(t *testing.T) {
 
 	const method = "addClientAdmin"
 
-	groupId := randomBytes(8)
+	groupId := randomBytes(5)
 
 	cOwn := e.WithSigners(owner)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, admPub)
@@ -230,7 +230,7 @@ func TestSubnet_RemoveClientAdmin(t *testing.T) {
 
 	const method = "removeClientAdmin"
 
-	groupId := randomBytes(8)
+	groupId := randomBytes(5)
 
 	cOwn := e.WithSigners(owner)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, admPub)
@@ -252,7 +252,7 @@ func TestSubnet_AddUser(t *testing.T) {
 
 	user := randomBytes(27)
 
-	groupId := randomBytes(8)
+	groupId := randomBytes(5)
 
 	const method = "addUser"
 
@@ -272,7 +272,7 @@ func TestSubnet_RemoveUser(t *testing.T) {
 
 	id, owner := createSubnet(t, e)
 
-	groupId := randomBytes(8)
+	groupId := randomBytes(5)
 	user := randomBytes(27)
 
 	adm := e.NewAccount(t)

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -45,7 +45,7 @@ func TestSubnet_Put(t *testing.T) {
 	pub, ok := vm.ParseSignatureContract(acc.Script())
 	require.True(t, ok)
 
-	id := make([]byte, 4)
+	id := make([]byte, 5)
 	binary.LittleEndian.PutUint32(id, 123)
 	info := randomBytes(10)
 
@@ -70,7 +70,8 @@ func TestSubnet_Delete(t *testing.T) {
 	e.InvokeFail(t, "witness check failed", "delete", id)
 
 	cAcc := e.WithSigners(owner)
-	cAcc.InvokeFail(t, subnet.ErrNotExist, "delete", []byte{1, 1, 1, 1})
+	cAcc.InvokeFail(t, subnet.ErrInvalidSubnetID, "delete", []byte{1, 1, 1, 1})
+	cAcc.InvokeFail(t, subnet.ErrNotExist, "delete", []byte{1, 1, 1, 1, 1})
 	cAcc.Invoke(t, stackitem.Null{}, "delete", id)
 	cAcc.InvokeFail(t, subnet.ErrNotExist, "get", id)
 	cAcc.InvokeFail(t, subnet.ErrNotExist, "delete", id)
@@ -87,8 +88,9 @@ func TestSubnet_AddNodeAdmin(t *testing.T) {
 
 	const method = "addNodeAdmin"
 
+	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, admPub)
 	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, admPub[1:])
-	e.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, admPub)
+	e.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, admPub)
 
 	cAdm := e.WithSigners(adm)
 	cAdm.InvokeFail(t, method+errSeparator+"owner witness check failed", method, id, admPub)
@@ -110,8 +112,9 @@ func TestSubnet_RemoveNodeAdmin(t *testing.T) {
 
 	const method = "removeNodeAdmin"
 
+	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, admPub)
 	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, admPub[1:])
-	e.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, admPub)
+	e.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, admPub)
 
 	cAdm := e.WithSigners(adm)
 	cAdm.InvokeFail(t, method+errSeparator+"owner witness check failed", method, id, admPub)
@@ -136,8 +139,9 @@ func TestSubnet_AddNode(t *testing.T) {
 	const method = "addNode"
 
 	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
 	cOwn.InvokeFail(t, method+errSeparator+"node has already been added", method, id, nodePub)
@@ -159,8 +163,9 @@ func TestSubnet_RemoveNode(t *testing.T) {
 	const method = "removeNode"
 
 	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNodeNotExist, method, id, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
@@ -184,8 +189,9 @@ func TestSubnet_NodeAllowed(t *testing.T) {
 	const method = "nodeAllowed"
 
 	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, nodePub)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, nodePub)
 	cOwn.Invoke(t, stackitem.NewBool(false), method, id, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
@@ -206,8 +212,9 @@ func TestSubnet_AddClientAdmin(t *testing.T) {
 	groupId := randomBytes(8)
 
 	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, admPub)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, groupId, admPub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
 	cOwn.InvokeFail(t, method+errSeparator+"client admin has already been added", method, id, groupId, admPub)
 }
@@ -226,8 +233,9 @@ func TestSubnet_RemoveClientAdmin(t *testing.T) {
 	groupId := randomBytes(8)
 
 	cOwn := e.WithSigners(owner)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, admPub)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, groupId, admPub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, admPub)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrClientAdmNotExist, method, id, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
@@ -249,7 +257,8 @@ func TestSubnet_AddUser(t *testing.T) {
 	const method = "addUser"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, groupId, user)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, user)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, user)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
 
@@ -273,7 +282,8 @@ func TestSubnet_RemoveUser(t *testing.T) {
 	const method = "removeUser"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, groupId, user)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidSubnetID, method, []byte{0, 0, 0, 0}, groupId, user)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, groupId, user)
 
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrUserNotExist, method, id, groupId, user)
 	cOwn.Invoke(t, stackitem.Null{}, "addUser", id, groupId, user)
@@ -290,14 +300,14 @@ func TestSubnet_UserAllowed(t *testing.T) {
 
 	id, owner := createSubnet(t, e)
 
-	groupId := randomBytes(4)
+	groupId := randomBytes(5)
 
 	user := randomBytes(27)
 
 	const method = "userAllowed"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, user)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0, 0}, user)
 
 	cOwn.Invoke(t, stackitem.NewBool(false), method, id, user)
 	cOwn.Invoke(t, stackitem.Null{}, "addUser", id, groupId, user)
@@ -314,7 +324,7 @@ func createSubnet(t *testing.T, e *neotest.ContractInvoker) (id []byte, owner ne
 	pub, ok = vm.ParseSignatureContract(owner.Script())
 	require.True(t, ok)
 
-	id = make([]byte, 4)
+	id = make([]byte, 5)
 	binary.LittleEndian.PutUint32(id, 123)
 	info := randomBytes(10)
 

--- a/tests/subnet_test.go
+++ b/tests/subnet_test.go
@@ -70,10 +70,10 @@ func TestSubnet_Delete(t *testing.T) {
 	e.InvokeFail(t, "witness check failed", "delete", id)
 
 	cAcc := e.WithSigners(owner)
-	cAcc.InvokeFail(t, subnet.ErrSubNotExist, "delete", []byte{1, 1, 1, 1})
+	cAcc.InvokeFail(t, subnet.ErrNotExist, "delete", []byte{1, 1, 1, 1})
 	cAcc.Invoke(t, stackitem.Null{}, "delete", id)
-	cAcc.InvokeFail(t, subnet.ErrSubNotExist, "get", id)
-	cAcc.InvokeFail(t, subnet.ErrSubNotExist, "delete", id)
+	cAcc.InvokeFail(t, subnet.ErrNotExist, "get", id)
+	cAcc.InvokeFail(t, subnet.ErrNotExist, "delete", id)
 }
 
 func TestSubnet_AddNodeAdmin(t *testing.T) {
@@ -88,7 +88,7 @@ func TestSubnet_AddNodeAdmin(t *testing.T) {
 	const method = "addNodeAdmin"
 
 	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, admPub[1:])
-	e.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, admPub)
+	e.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, admPub)
 
 	cAdm := e.WithSigners(adm)
 	cAdm.InvokeFail(t, method+errSeparator+"owner witness check failed", method, id, admPub)
@@ -111,7 +111,7 @@ func TestSubnet_RemoveNodeAdmin(t *testing.T) {
 	const method = "removeNodeAdmin"
 
 	e.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, admPub[1:])
-	e.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, admPub)
+	e.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, admPub)
 
 	cAdm := e.WithSigners(adm)
 	cAdm.InvokeFail(t, method+errSeparator+"owner witness check failed", method, id, admPub)
@@ -137,7 +137,7 @@ func TestSubnet_AddNode(t *testing.T) {
 
 	cOwn := e.WithSigners(owner)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, method, id, nodePub)
 	cOwn.InvokeFail(t, method+errSeparator+"node has already been added", method, id, nodePub)
@@ -160,7 +160,7 @@ func TestSubnet_RemoveNode(t *testing.T) {
 
 	cOwn := e.WithSigners(owner)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, nodePub)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNodeNotExist, method, id, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
@@ -185,7 +185,7 @@ func TestSubnet_NodeAllowed(t *testing.T) {
 
 	cOwn := e.WithSigners(owner)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidNode, method, id, nodePub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, nodePub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, nodePub)
 	cOwn.Invoke(t, stackitem.NewBool(false), method, id, nodePub)
 
 	cOwn.Invoke(t, stackitem.Null{}, "addNode", id, nodePub)
@@ -207,7 +207,7 @@ func TestSubnet_AddClientAdmin(t *testing.T) {
 
 	cOwn := e.WithSigners(owner)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, groupId, admPub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
 	cOwn.InvokeFail(t, method+errSeparator+"client admin has already been added", method, id, groupId, admPub)
 }
@@ -227,7 +227,7 @@ func TestSubnet_RemoveClientAdmin(t *testing.T) {
 
 	cOwn := e.WithSigners(owner)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrInvalidAdmin, method, id, groupId, admPub[1:])
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, groupId, admPub)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, groupId, admPub)
 	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrClientAdmNotExist, method, id, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, "addClientAdmin", id, groupId, admPub)
 	cOwn.Invoke(t, stackitem.Null{}, method, id, groupId, admPub)
@@ -297,7 +297,7 @@ func TestSubnet_UserAllowed(t *testing.T) {
 	const method = "userAllowed"
 
 	cOwn := e.WithSigners(owner)
-	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrSubNotExist, method, []byte{0, 0, 0, 0}, user)
+	cOwn.InvokeFail(t, method+errSeparator+subnet.ErrNotExist, method, []byte{0, 0, 0, 0}, user)
 
 	cOwn.Invoke(t, stackitem.NewBool(false), method, id, user)
 	cOwn.Invoke(t, stackitem.Null{}, "addUser", id, groupId, user)


### PR DESCRIPTION
After internal discussion, it was decided to use `NodeAllowed(...) bool` and `UserAllowed(...) bool` instead of `ListNodes()` and `ListUsers()` methods due to the current use cases (at least for now).

This PR considers that `groupID` is defined and fixed (has fixed len of 5 bytes) since the contract needs to know an offset in its storage keys to the user's `ownerID`. It is discussable.

Closes #122.