### PR TITLE
nns: allow to register arbitrary-level domains

### DIFF
--- a/nns/nns_contract.go
+++ b/nns/nns_contract.go
@@ -298,6 +298,17 @@ func Register(name string, owner interop.Hash160, email string, refresh, retry, 
 		nsBytes := storage.Get(ctx, append([]byte{prefixName}, parentKey...))
 		ns := std.Deserialize(nsBytes.([]byte)).(NameState)
 		ns.checkAdmin()
+
+		parentRecKey := append([]byte{prefixRecord}, parentKey...)
+		it := storage.Find(ctx, parentRecKey, storage.ValuesOnly|storage.DeserializeValues)
+		suffix := []byte(name)
+		for iterator.Next(it) {
+			r := iterator.Value(it).(RecordState)
+			ind := std.MemorySearchLastIndex([]byte(r.Name), suffix, len(r.Name))
+			if ind > 0 && ind+len(suffix) == len(r.Name) {
+				panic("parent domain has conflicting records: " + r.Name)
+			}
+		}
 	}
 
 	if !isValid(owner) {

--- a/tests/nns_test.go
+++ b/tests/nns_test.go
@@ -166,7 +166,17 @@ func TestNNSRegisterMulti(t *testing.T) {
 	args = newArgs("mainnet.fs.neo.com", acc2)
 	c2.InvokeFail(t, "not witnessed by admin", "register", args...)
 
+	c1.Invoke(t, stackitem.Null{}, "addRecord",
+		"something.mainnet.fs.neo.com", int64(nns.A), "1.2.3.4")
+	c1.Invoke(t, stackitem.Null{}, "addRecord",
+		"another.fs.neo.com", int64(nns.A), "4.3.2.1")
+
 	c2 = c.WithSigners(acc, acc2)
+	c2.InvokeFail(t, "parent domain has conflicting records: something.mainnet.fs.neo.com",
+		"register", args...)
+
+	c1.Invoke(t, stackitem.Null{}, "deleteRecords",
+		"something.mainnet.fs.neo.com", int64(nns.A))
 	c2.Invoke(t, true, "register", args...)
 
 	c2 = c.WithSigners(acc2)


### PR DESCRIPTION
Close #172 .

So there are two problems which needs to be discussed:
1. I register a domain `a.com` and register an A record `y.z.a.com` for it. What should happen if I register `z.a.com` domain? Current behaviour: fail registration with the error message showing conflicting record.
2. I register a domain `y.z.com` and a record `x.y.z.com`. What happens with record `x.y.z.com`?
Current behaviour: it will fail to resolve.
Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>