### PR TITLE
[#154] netmap: implement `Register` method

### DIFF
--- a/tests/netmap_test.go
+++ b/tests/netmap_test.go
@@ -90,6 +90,9 @@ func TestAddPeer(t *testing.T) {
 	require.Equal(t, "AddPeer", aer.Events[0].Name)
 	require.Equal(t, stackitem.NewArray([]stackitem.Item{stackitem.NewByteArray(dummyInfo)}),
 		aer.Events[0].Item)
+
+	c.InvokeFail(t, common.ErrWitnessFailed, "addPeer", dummyInfo)
+	c.Invoke(t, stackitem.Null{}, "register", dummyInfo)
 }
 
 func TestUpdateState(t *testing.T) {


### PR DESCRIPTION
Close #154.

For notary-disabled environment it makes sense to split node
registration and actual candidate update into separate methods.
This way we have less complicate logic in `AddPeer` and overall
registration flow is more understandable.

Signed-off-by: Evgenii Stratonikov <evgeniy@nspcc.ru>