### PR TITLE
Fix/Check `NeoFS` role for the next block

### DIFF
--- a/common/ir.go
+++ b/common/ir.go
@@ -32,7 +32,7 @@ func InnerRingInvoker(ir []IRNode) interop.PublicKey {
 // in side chain.
 func InnerRingNodes() []IRNode {
 	blockHeight := ledger.CurrentIndex()
-	list := roles.GetDesignatedByRole(roles.NeoFSAlphabet, uint32(blockHeight))
+	list := roles.GetDesignatedByRole(roles.NeoFSAlphabet, uint32(blockHeight+1))
 	return keysToNodes(list)
 }
 


### PR DESCRIPTION
Current height makes it impossible to change
roles and make some operations in one block.
Also, it may lead to accepting some operations
that are approved by already not valid alphabet.

Signed-off-by: Pavel Karpy <carpawell@nspcc.ru>