### PR TITLE
Release/v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 Changelog for NeoFS Contract
 
+## [0.14.0] - 2022-01-14 - Geojedo (거제도, 巨濟島)
+
+### Fixed
+- Sync `Update` method signature in NNS contract (#197)
+- Use current block index in all `GetDisgnatedByRole` invocations (#209)
+
+### Added
+- Version check during contract update (#204)
+
+### Changed
+- Use `storage.RemovePrefix` in subnet contract (#199)
+
+### Removed
+- Netmap contract hash usage in proxy contract (#205)
+- Legacy contract owner records from contract storage (#202)
+
 ## [0.13.2] - 2021-12-14
 
 ### Fixed
@@ -294,6 +310,7 @@ Preview4-testnet version of NeoFS contracts.
 
 Preview4 compatible contracts.
 
+[0.14.0]: https://github.com/nspcc-dev/neofs-contract/compare/v0.13.2...v0.14.0
 [0.13.2]: https://github.com/nspcc-dev/neofs-contract/compare/v0.13.1...v0.13.2
 [0.13.1]: https://github.com/nspcc-dev/neofs-contract/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/nspcc-dev/neofs-contract/compare/v0.12.2...v0.13.0

--- a/common/version.go
+++ b/common/version.go
@@ -4,15 +4,15 @@ import "github.com/nspcc-dev/neo-go/pkg/interop/native/std"
 
 const (
 	major = 0
-	minor = 13
-	patch = 2
+	minor = 14
+	patch = 0
 
 	// Versions from which an update should be performed.
 	// These should be used in a group (so prevMinor can be equal to minor if there are
 	// any migration routines.
 	prevMajor = 0
-	prevMinor = 12
-	prevPatch = 2
+	prevMinor = 13
+	prevPatch = 0
 
 	Version = major*1_000_000 + minor*1_000 + patch
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,6 @@ go 1.14
 
 require (
 	github.com/mr-tron/base58 v1.2.0
-	github.com/nspcc-dev/neo-go v0.98.1-pre.0.20220110205632-fcbb0aacc2fe
+	github.com/nspcc-dev/neo-go v0.98.0
 	github.com/stretchr/testify v1.7.0
 )

--- a/go.sum
+++ b/go.sum
@@ -173,8 +173,8 @@ github.com/nspcc-dev/go-ordered-json v0.0.0-20210915112629-e1b6cce73d02/go.mod h
 github.com/nspcc-dev/hrw v1.0.9 h1:17VcAuTtrstmFppBjfRiia4K2wA/ukXZhLFS8Y8rz5Y=
 github.com/nspcc-dev/hrw v1.0.9/go.mod h1:l/W2vx83vMQo6aStyx2AuZrJ+07lGv2JQGlVkPG06MU=
 github.com/nspcc-dev/neo-go v0.73.1-pre.0.20200303142215-f5a1b928ce09/go.mod h1:pPYwPZ2ks+uMnlRLUyXOpLieaDQSEaf4NM3zHVbRjmg=
-github.com/nspcc-dev/neo-go v0.98.1-pre.0.20220110205632-fcbb0aacc2fe h1:GcZ15OvNOi2EJhx4oseOAJqSPEhR0GP/zzY2HIPl3Qw=
-github.com/nspcc-dev/neo-go v0.98.1-pre.0.20220110205632-fcbb0aacc2fe/go.mod h1:E3cc1x6RXSXrJb2nDWXTXjnXk3rIqVN8YdFyWv+FrqM=
+github.com/nspcc-dev/neo-go v0.98.0 h1:yyW4sgY88/pLf0949qmgfkQXzRKC3CI/WyhqXNnwMd8=
+github.com/nspcc-dev/neo-go v0.98.0/go.mod h1:E3cc1x6RXSXrJb2nDWXTXjnXk3rIqVN8YdFyWv+FrqM=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.0-pre.0.20211201134523-3604d96f3fe1 h1:CGA56mhLLduWRuMHcWujP5Ek+gAnXHk0WuIWkG65G1s=
 github.com/nspcc-dev/neofs-api-go/v2 v2.11.0-pre.0.20211201134523-3604d96f3fe1/go.mod h1:oS8dycEh8PPf2Jjp6+8dlwWyEv2Dy77h/XhhcdxYEFs=
 github.com/nspcc-dev/neofs-crypto v0.2.0/go.mod h1:F/96fUzPM3wR+UGsPi3faVNmFlA9KAEAUQR7dMxZmNA=

--- a/tests/alphabet_test.go
+++ b/tests/alphabet_test.go
@@ -18,6 +18,11 @@ import (
 
 const alphabetPath = "../alphabet"
 
+// FIXME: delete after https://github.com/nspcc-dev/neo-go/issues/2297
+const singleValidatorWIF = "KxyjQ8eUa4FHt3Gvioyt1Wz29cTUrE4eTqX3yFSk1YFCsPL8uNsY"
+
+var committeeAcc, _ = wallet.NewAccountFromWIF(singleValidatorWIF)
+
 func deployAlphabetContract(t *testing.T, e *neotest.Executor, addrNetmap, addrProxy util.Uint160, name string, index, total int64) util.Uint160 {
 	c := neotest.CompileFile(t, e.CommitteeHash, alphabetPath, path.Join(alphabetPath, "config.yml"))
 
@@ -51,9 +56,7 @@ func newAlphabetInvoker(t *testing.T) (*neotest.Executor, *neotest.ContractInvok
 	deployProxyContract(t, e, ctrNetmap.Hash)
 	hash := deployAlphabetContract(t, e, ctrNetmap.Hash, ctrProxy.Hash, "Az", 0, 1)
 
-	alphabet := getAlphabetAcc(t, e)
-
-	setAlphabetRole(t, e, alphabet.PrivateKey().PublicKey().Bytes())
+	setAlphabetRole(t, e, committeeAcc.PrivateKey().PublicKey().Bytes())
 
 	return e, e.CommitteeInvoker(hash)
 }
@@ -63,9 +66,7 @@ func TestEmit(t *testing.T) {
 
 	const method = "emit"
 
-	alphabet := getAlphabetAcc(t, c.Executor)
-
-	cCommittee := c.WithSigners(neotest.NewSingleSigner(alphabet))
+	cCommittee := c.WithSigners(neotest.NewSingleSigner(committeeAcc))
 	cCommittee.InvokeFail(t, "no gas to emit", method)
 
 	transferNeoToContract(t, c)
@@ -140,11 +141,4 @@ func setAlphabetRole(t *testing.T, e *neotest.Executor, new []byte) {
 
 	// set committee as NeoFSAlphabet
 	designInvoker.Invoke(t, stackitem.Null{}, "designateAsRole", int64(noderoles.NeoFSAlphabet), []interface{}{new})
-}
-
-func getAlphabetAcc(t *testing.T, e *neotest.Executor) *wallet.Account {
-	multi, ok := e.Committee.(neotest.MultiSigner)
-	require.True(t, ok)
-
-	return multi.Single(0).Account()
 }


### PR DESCRIPTION
Neotest changes from #198 require neo-go version bump and this bump is incompatible with latest stable neo-go version. Other commits didn't require version bump so I reverted it until we will get new neo-go release.