### PR TITLE
Fix reputation and subnet contract update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 Changelog for NeoFS Contract
 
+## [0.14.1] - 2022-01-24
+
+### Fixed
+- Remove migration routine for reputation contract update (#220)
+- Remove version check for subnet contract update (#220)
+
+### Added
+- Append version to `Update` arguments for subnet contract (#220)
+
 ## [0.14.0] - 2022-01-14 - Geojedo (거제도, 巨濟島)
 
 ### Fixed

--- a/common/version.go
+++ b/common/version.go
@@ -5,7 +5,7 @@ import "github.com/nspcc-dev/neo-go/pkg/interop/native/std"
 const (
 	major = 0
 	minor = 14
-	patch = 0
+	patch = 1
 
 	// Versions from which an update should be performed.
 	// These should be used in a group (so prevMinor can be equal to minor if there are

--- a/reputation/reputation_contract.go
+++ b/reputation/reputation_contract.go
@@ -6,7 +6,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/interop/convert"
 	"github.com/nspcc-dev/neo-go/pkg/interop/iterator"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
-	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
 	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
 	"github.com/nspcc-dev/neo-go/pkg/interop/storage"
 	"github.com/nspcc-dev/neofs-contract/common"
@@ -25,31 +24,7 @@ func _deploy(data interface{}, isUpdate bool) {
 		args := data.([]interface{})
 		common.CheckVersion(args[len(args)-1].(int))
 
-		// Storage migration.
 		storage.Delete(ctx, []byte("contractOwner"))
-
-		it := storage.Find(ctx, []byte{}, storage.None)
-		for iterator.Next(it) {
-			kv := iterator.Value(it).([][]byte)
-			if string(kv[0]) == notaryDisabledKey {
-				continue
-			}
-			if string(kv[0]) == "ballots" {
-				continue
-			}
-
-			storage.Delete(ctx, kv[0])
-
-			rawValues := std.Deserialize(kv[1]).([][]byte)
-			key := getReputationKey(reputationCountPrefix, kv[0])
-			storage.Put(ctx, key, len(rawValues))
-
-			key[0] = reputationValuePrefix
-			for i := range rawValues {
-				newKey := append(key, convert.ToBytes(i)...)
-				storage.Put(ctx, newKey, rawValues[i])
-			}
-		}
 		return
 	}
 

--- a/subnet/subnet_contract.go
+++ b/subnet/subnet_contract.go
@@ -58,8 +58,8 @@ const (
 // _deploy function sets up initial list of inner ring public keys.
 func _deploy(data interface{}, isUpdate bool) {
 	if isUpdate {
-		args := data.([]interface{})
-		common.CheckVersion(args[len(args)-1].(int))
+		//args := data.([]interface{})
+		//common.CheckVersion(args[len(args)-1].(int))
 		return
 	}
 
@@ -78,7 +78,8 @@ func Update(script []byte, manifest []byte, data interface{}) {
 		panic("only committee can update contract")
 	}
 
-	contract.Call(interop.Hash160(management.Hash), "update", contract.All, script, manifest, data)
+	contract.Call(interop.Hash160(management.Hash), "update", contract.All,
+		script, manifest, common.AppendVersion(data))
 	runtime.Log("subnet contract updated")
 }
 


### PR DESCRIPTION
While updating v0.13.1 to v0.14.0 some errors emerged:

1. Subnet contract does not append version.
2. Reputation contract should no longer have transition code.