### PR TITLE
Fix maxDomainNameFragmentLength

### DIFF
--- a/nns/nns_contract.go
+++ b/nns/nns_contract.go
@@ -50,7 +50,7 @@ const (
 	// maxRootLength is the maximum domain root length.
 	maxRootLength = 16
 	// maxDomainNameFragmentLength is the maximum length of the domain name fragment.
-	maxDomainNameFragmentLength = 62
+	maxDomainNameFragmentLength = 63
 	// minDomainNameLength is minimum domain length.
 	minDomainNameLength = 3
 	// maxDomainNameLength is maximum domain length.


### PR DESCRIPTION
If I understand correctly, `maxDomainNameFragmentLength` means maximum length of label of domain name. 
By [wiki](https://en.wikipedia.org/wiki/Domain_Name_System#Domain_name_syntax,_internationalization) and [spec](https://datatracker.ietf.org/doc/html/rfc1034#section-3.1):
```
A label may contain zero to 63 characters. The null label, of length zero, is reserved for the root zone. The full domain name may not exceed the length of 253 characters in its textual representation
```

But now we compare with 62 and don't allow labels with 63 octets length. 