### PR TITLE
Adjust container-contract permissions

### DIFF
--- a/container/config.yml
+++ b/container/config.yml
@@ -2,7 +2,7 @@ name: "NeoFS Container"
 safemethods: ["count", "get", "owner", "list", "eACL", "getContainerSize", "listContainerSizes", "version"]
 permissions:
   - methods: ["update", "addKey", "transferX",
-               "addRoot", "register", "addRecord", "deleteRecords"]
+               "register", "addRecord", "deleteRecords"]
 events:
   - name: containerPut
     parameters:


### PR DESCRIPTION
Remove "addRoot" method from the list of allowed methods, because
NNS doesn't have it since
https://github.com/nspcc-dev/neofs-contract/pull/139/commits/4b86891d57ef12c3f37a9ef27902c73d96812934.