### PR TITLE
netmap: Return same type from reading methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,21 @@ Changelog for NeoFS Contract
 
 ## Unrelease
 
+### Added
+- Support `MAINTENANCE` state of storage nodes (#269)
+
+### Changed
+- `netmap.Snapshot` and all similar methods return (#269)
+
 ### Updated
 - NNS contract now sets domain expiration based on `register` arguments (#262)
 
 ### Fixed
 - NNS `renew` now can only be done by the domain owner
+
+### Updating from v0.15.x
+Update deployed `Netmap` contract using `Update` method: storage of the contract
+has been incompatibly changed.
 
 ## [0.15.5] - 2022-08-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 Changelog for NeoFS Contract
 
-## Unrelease
+## [Unreleased]
 
 ### Added
 - Support `MAINTENANCE` state of storage nodes (#269)
@@ -395,6 +395,7 @@ Preview4-testnet version of NeoFS contracts.
 
 Preview4 compatible contracts.
 
+[Unreleased]: https://github.com/nspcc-dev/neofs-contract/compare/v0.15.5...master
 [0.15.5]: https://github.com/nspcc-dev/neofs-contract/compare/v0.15.4...v0.15.5
 [0.15.4]: https://github.com/nspcc-dev/neofs-contract/compare/v0.15.3...v0.15.4
 [0.15.3]: https://github.com/nspcc-dev/neofs-contract/compare/v0.15.2...v0.15.3


### PR DESCRIPTION
* relates to #269

I've changed format of the Netmap contract storage - should I do some compatibility actions? @fyrchik 