### PR TITLE
Correct getcontainersize api

### DIFF
--- a/container/config.yml
+++ b/container/config.yml
@@ -1,5 +1,5 @@
 name: "NeoFS Container"
-safemethods: ["count", "containersOf", "get", "owner", "list", "eACL", "getContainerSize", "listContainerSizes", "iterateContainerSizes", "version"]
+safemethods: ["count", "containersOf", "get", "owner", "list", "eACL", "getContainerSize", "listContainerSizes", "iterateContainerSizes", "iterateAllContainerSizes", "version"]
 permissions:
   - methods: ["update", "addKey", "transferX",
                "register", "addRecord", "deleteRecords"]

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -559,6 +559,11 @@ func PutContainerSize(epoch int, cid []byte, usedSize int, pubKey interop.Public
 func GetContainerSize(id []byte) containerSizes {
 	ctx := storage.GetReadOnlyContext()
 
+	if len(id) < len(estimateKeyPrefix)+containerIDSize ||
+		string(id[:len(estimateKeyPrefix)]) != estimateKeyPrefix {
+		panic("wrong estimation prefix")
+	}
+
 	// V2 format
 	// this `id` expected to be from `ListContainerSizes`
 	// therefore it is not contains postfix, we ignore it in the cut.

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -32,14 +32,16 @@ type (
 		token []byte
 	}
 
-	estimation struct {
-		from interop.PublicKey
-		size int
+	// Estimation contains the public key of the estimator (storage node) and
+	// the size this estimator has for the container.
+	Estimation struct {
+		From interop.PublicKey
+		Size int
 	}
 
 	containerSizes struct {
 		cid         []byte
-		estimations []estimation
+		estimations []Estimation
 	}
 )
 
@@ -538,9 +540,9 @@ func PutContainerSize(epoch int, cid []byte, usedSize int, pubKey interop.Public
 
 	key := estimationKey(epoch, cid, pubKey)
 
-	s := estimation{
-		from: pubKey,
-		size: usedSize,
+	s := Estimation{
+		From: pubKey,
+		Size: usedSize,
 	}
 
 	storage.Put(ctx, key, std.Serialize(s))
@@ -607,7 +609,7 @@ func ListContainerSizes(epoch int) [][]byte {
 
 // IterateContainerSizes method returns iterator over specific container size
 // estimations that have been registered for the specified epoch. The iterator items
-// are estimate structures with estimator public key and his estimation integer value.
+// are Estimation structures.
 func IterateContainerSizes(epoch int, cid interop.Hash256) iterator.Iterator {
 	if len(cid) != interop.Hash256Len {
 		panic("wrong container id")
@@ -626,8 +628,8 @@ func IterateContainerSizes(epoch int, cid interop.Hash256) iterator.Iterator {
 
 // IterateAllContainerSizes method returns iterator over all container size estimations
 // that have been registered for the specified epoch. Items returned from this iterator
-// are key-value pairs with keys having container ID as a prefix and values being estimate
-// structures with estimator public key and his estimation integer value.
+// are key-value pairs with keys having container ID as a prefix and values being Estimation
+// structures.
 func IterateAllContainerSizes(epoch int) iterator.Iterator {
 	ctx := storage.GetReadOnlyContext()
 
@@ -753,11 +755,11 @@ func estimationKey(epoch int, cid []byte, key interop.PublicKey) []byte {
 }
 
 func getContainerSizeEstimation(ctx storage.Context, key, cid []byte) containerSizes {
-	var estimations []estimation
+	var estimations []Estimation
 
 	it := storage.Find(ctx, key, storage.ValuesOnly|storage.DeserializeValues)
 	for iterator.Next(it) {
-		est := iterator.Value(it).(estimation)
+		est := iterator.Value(it).(Estimation)
 		estimations = append(estimations, est)
 	}
 

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -558,6 +558,10 @@ func PutContainerSize(epoch int, cid []byte, usedSize int, pubKey interop.Public
 // Use the ID obtained from ListContainerSizes method. Estimations are removed
 // from contract storage every epoch, see NewEpoch method; therefore, this method
 // can return different results during different epochs.
+//
+// Deprecated: please use IterateContainerSizes API, this one is not convenient
+// to use and limited in the number of items it can return. It will be removed in
+// future versions.
 func GetContainerSize(id []byte) containerSizes {
 	ctx := storage.GetReadOnlyContext()
 
@@ -577,6 +581,10 @@ func GetContainerSize(id []byte) containerSizes {
 
 // ListContainerSizes method returns the IDs of container size estimations
 // that have been registered for the specified epoch.
+//
+// Deprecated: please use IterateAllContainerSizes API, this one is not convenient
+// to use and limited in the number of items it can return. It will be removed in
+// future versions.
 func ListContainerSizes(epoch int) [][]byte {
 	ctx := storage.GetReadOnlyContext()
 

--- a/tests/container_test.go
+++ b/tests/container_test.go
@@ -362,6 +362,10 @@ func TestContainerSizeEstimation(t *testing.T) {
 			int64(2), cnt.id[:], int64(123), nodes[0].pub)
 	})
 
+	t.Run("incorrect key must fail", func(t *testing.T) {
+		_, err := c.TestInvoke(t, "getContainerSize", cnt.id[:])
+		require.Error(t, err)
+	})
 	c.WithSigners(nodes[0].signer).Invoke(t, stackitem.Null{}, "putContainerSize",
 		int64(2), cnt.id[:], int64(123), nodes[0].pub)
 	estimations := []estimation{{nodes[0].pub, 123}}


### PR DESCRIPTION
I want to include this into 0.17.0 to have something for the nspcc-dev/neofs-node#2173 to use.