### PR TITLE
container: Check eACL input in `setEACL` method's implementation

### DIFF
--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -477,8 +477,15 @@ func SetEACL(eACL []byte, signature interop.Signature, publicKey interop.PublicK
 
 	// V2 format
 	// get container ID
+	lnEACL := len(eACL)
+	if lnEACL < 2 {
+		panic("missing version field in eACL BLOB")
+	}
 	offset := int(eACL[1])
 	offset = 2 + offset + 4
+	if lnEACL < offset+containerIDSize {
+		panic("missing container ID field in eACL BLOB")
+	}
 	containerID := eACL[offset : offset+containerIDSize]
 
 	ownerID := getOwnerByID(ctx, containerID)

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -465,7 +465,9 @@ func List(owner []byte) [][]byte {
 // if it was invoked by Alphabet nodes of the Inner Ring. Otherwise, it produces
 // setEACL notification.
 //
-// EACL should be a stable marshaled EACLTable structure from API.
+// EACL should be a stable marshaled EACLTable structure from API. Protocol
+// version and container reference must be set in 'version' and 'container_id'
+// fields respectively.
 // Signature is a RFC6979 signature of the Container.
 // PublicKey contains the public key of the signer.
 // Token is optional and should be a stable marshaled SessionToken structure from


### PR DESCRIPTION
* relates #329