### PR TITLE
common: ignore stale votes in TryPurgeVotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 # Changelog
 Changelog for NeoFS Contract
 
+## [Unreleased]
+
+### Added
+
+### Updated
+
+### Removed
+
+### Fixed
+- migration of non-notary network to notarized one with stale votes
+
+### Updating from v0.17.0
+
 ## [0.17.0] - 2023-04-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -439,7 +439,8 @@ Preview4-testnet version of NeoFS contracts.
 
 Preview4 compatible contracts.
 
-[Unreleased]: https://github.com/nspcc-dev/neofs-contract/compare/v0.16.0...master
+[Unreleased]: https://github.com/nspcc-dev/neofs-contract/compare/v0.17.0...master
+[0.17.0]: https://github.com/nspcc-dev/neofs-contract/compare/v0.16.0...v0.17.0
 [0.16.0]: https://github.com/nspcc-dev/neofs-contract/compare/v0.15.5...v0.16.0
 [0.15.5]: https://github.com/nspcc-dev/neofs-contract/compare/v0.15.4...v0.15.5
 [0.15.4]: https://github.com/nspcc-dev/neofs-contract/compare/v0.15.3...v0.15.4

--- a/common/vote.go
+++ b/common/vote.go
@@ -99,8 +99,16 @@ func RemoveVotes(ctx storage.Context, id []byte) {
 // TryPurgeVotes removes storage item by 'ballots' key if it doesn't contain any
 // in-progress vote. Otherwise, TryPurgeVotes returns false.
 func TryPurgeVotes(ctx storage.Context) bool {
-	if len(getBallots(ctx)) > 0 {
-		return false
+	var (
+		candidates  = getBallots(ctx)
+		blockHeight = ledger.CurrentIndex()
+	)
+	for i := 0; i < len(candidates); i++ {
+		cnd := candidates[i]
+
+		if blockHeight-cnd.Height <= blockDiff {
+			return false
+		}
 	}
 
 	storage.Delete(ctx, voteKey)


### PR DESCRIPTION
On a real healthy network we _always_ have something there. Consider seven IRs doing something, we only need five signatures, so they're added and then dropped when we have enough of them, but excessive transactions from the other IRs still come and they will be added again into the same voting structure.

But according to the definition of blockDiff we can ignore stale votes safely (they're not counted for votes anyway).