### PR TITLE
rpc: export unexported fields of public structures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ export GOBIN ?= $(shell pwd)/bin
 export CGO_ENABLED=0
 NEOGO ?= $(GOBIN)/cli
 VERSION ?= $(shell git describe --tags --dirty --match "v*" --always --abbrev=8 2>/dev/null || cat VERSION 2>/dev/null || echo "develop")
-NEOGOORIGMOD = github.com/nspcc-dev/neo-go@v0.101.5-0.20230802075307-afa4530c7d73
+NEOGOORIGMOD = github.com/nspcc-dev/neo-go@v0.101.5-0.20230811151147-4e61e8238a6d
 NEOGOMOD = $(shell go list -f '{{.Path}}' -m $(NEOGOORIGMOD))
 NEOGOVER = $(shell go list -f '{{.Version}}' -m $(NEOGOORIGMOD) | tr -d v)
 

--- a/audit/audit_contract.go
+++ b/audit/audit_contract.go
@@ -12,10 +12,10 @@ import (
 )
 
 type (
-	auditHeader struct {
-		epoch int
-		cid   []byte
-		from  interop.PublicKey
+	AuditHeader struct {
+		Epoch int
+		CID   []byte
+		From  interop.PublicKey
 	}
 )
 
@@ -27,13 +27,13 @@ type (
 // V2 format
 const maxKeySize = 24 // 24 + 32 (container ID length) + 8 (epoch length) = 64
 
-func (a auditHeader) ID() []byte {
-	var buf interface{} = a.epoch
+func (a AuditHeader) ID() []byte {
+	var buf interface{} = a.Epoch
 
-	hashedKey := crypto.Sha256(a.from)
+	hashedKey := crypto.Sha256(a.From)
 	shortedKey := hashedKey[:maxKeySize]
 
-	return append(buf.([]byte), append(a.cid, shortedKey...)...)
+	return append(buf.([]byte), append(a.CID, shortedKey...)...)
 }
 
 // nolint:deadcode,unused
@@ -113,14 +113,14 @@ func Put(rawAuditResult []byte) {
 
 	for i := range innerRing {
 		ir := innerRing[i]
-		if common.BytesEqual(ir, hdr.from) {
+		if common.BytesEqual(ir, hdr.From) {
 			presented = true
 
 			break
 		}
 	}
 
-	if !runtime.CheckWitness(hdr.from) || !presented {
+	if !runtime.CheckWitness(hdr.From) || !presented {
 		panic("put access denied")
 	}
 
@@ -173,10 +173,10 @@ func ListByCID(epoch int, cid []byte) [][]byte {
 // the specified epoch for the specified container by the specified Inner Ring node.
 func ListByNode(epoch int, cid []byte, key interop.PublicKey) [][]byte {
 	ctx := storage.GetReadOnlyContext()
-	hdr := auditHeader{
-		epoch: epoch,
-		cid:   cid,
-		from:  key,
+	hdr := AuditHeader{
+		Epoch: epoch,
+		CID:   cid,
+		From:  key,
 	}
 
 	it := storage.Find(ctx, hdr.ID(), storage.KeysOnly)
@@ -208,7 +208,7 @@ func readNext(input []byte) ([]byte, int) {
 	return input[1 : 1+ln], 1 + ln
 }
 
-func newAuditHeader(input []byte) auditHeader {
+func newAuditHeader(input []byte) AuditHeader {
 	// V2 format
 	offset := int(input[1])
 	offset = 2 + offset + 1 // version prefix + version len + epoch prefix
@@ -226,7 +226,7 @@ func newAuditHeader(input []byte) auditHeader {
 	// [ public key wireType (1 byte), ... ]
 	key, _ := readNext(input[offset+2+1+cidOffset+1:])
 
-	return auditHeader{
+	return AuditHeader{
 		epoch,
 		cid,
 		key,

--- a/neofs/neofs_contract.go
+++ b/neofs/neofs_contract.go
@@ -16,9 +16,9 @@ import (
 )
 
 type (
-	record struct {
-		key []byte
-		val []byte
+	Record struct {
+		Key []byte
+		Val []byte
 	}
 )
 
@@ -509,10 +509,10 @@ func SetConfig(id, key, val []byte) {
 
 // ListConfig returns an array of structures that contain a key and a value of all
 // NeoFS configuration records. Key and value are both byte arrays.
-func ListConfig() []record {
+func ListConfig() []Record {
 	ctx := storage.GetReadOnlyContext()
 
-	var config []record
+	var config []Record
 
 	it := storage.Find(ctx, configPrefix, storage.None)
 	for iterator.Next(it) {
@@ -520,7 +520,7 @@ func ListConfig() []record {
 			key []byte
 			val []byte
 		})
-		r := record{key: pair.key[len(configPrefix):], val: pair.val}
+		r := Record{Key: pair.key[len(configPrefix):], Val: pair.val}
 
 		config = append(config, r)
 	}

--- a/rpc/audit/rpcbinding.go
+++ b/rpc/audit/rpcbinding.go
@@ -15,10 +15,10 @@ import (
 	"unicode/utf8"
 )
 
-// AuditauditHeader is a contract-specific audit.auditHeader type used by its methods.
-type AuditauditHeader struct {
+// AuditAuditHeader is a contract-specific audit.AuditHeader type used by its methods.
+type AuditAuditHeader struct {
 	Epoch *big.Int
-	Cid []byte
+	CID []byte
 	From *keys.PublicKey
 }
 
@@ -263,19 +263,19 @@ func (c *Contract) UpdateUnsigned(script []byte, manifest []byte, data any) (*tr
 	return c.actor.MakeUnsignedCall(c.hash, "update", nil, script, manifest, data)
 }
 
-// itemToAuditauditHeader converts stack item into *AuditauditHeader.
-func itemToAuditauditHeader(item stackitem.Item, err error) (*AuditauditHeader, error) {
+// itemToAuditAuditHeader converts stack item into *AuditAuditHeader.
+func itemToAuditAuditHeader(item stackitem.Item, err error) (*AuditAuditHeader, error) {
 	if err != nil {
 		return nil, err
 	}
-	var res = new(AuditauditHeader)
+	var res = new(AuditAuditHeader)
 	err = res.FromStackItem(item)
 	return res, err
 }
 
-// FromStackItem retrieves fields of AuditauditHeader from the given
+// FromStackItem retrieves fields of AuditAuditHeader from the given
 // [stackitem.Item] or returns an error if it's not possible to do to so.
-func (res *AuditauditHeader) FromStackItem(item stackitem.Item) error {
+func (res *AuditAuditHeader) FromStackItem(item stackitem.Item) error {
 	arr, ok := item.Value().([]stackitem.Item)
 	if !ok {
 		return errors.New("not an array")
@@ -295,9 +295,9 @@ func (res *AuditauditHeader) FromStackItem(item stackitem.Item) error {
 	}
 
 	index++
-	res.Cid, err = arr[index].TryBytes()
+	res.CID, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field Cid: %w", err)
+		return fmt.Errorf("field CID: %w", err)
 	}
 
 	index++

--- a/rpc/audit/rpcbinding.go
+++ b/rpc/audit/rpcbinding.go
@@ -17,9 +17,9 @@ import (
 
 // AuditauditHeader is a contract-specific audit.auditHeader type used by its methods.
 type AuditauditHeader struct {
-	epoch *big.Int
-	cid []byte
-	from *keys.PublicKey
+	Epoch *big.Int
+	Cid []byte
+	From *keys.PublicKey
 }
 
 // CommonBallot is a contract-specific common.Ballot type used by its methods.
@@ -289,19 +289,19 @@ func (res *AuditauditHeader) FromStackItem(item stackitem.Item) error {
 		err error
 	)
 	index++
-	res.epoch, err = arr[index].TryInteger()
+	res.Epoch, err = arr[index].TryInteger()
 	if err != nil {
-		return fmt.Errorf("field epoch: %w", err)
+		return fmt.Errorf("field Epoch: %w", err)
 	}
 
 	index++
-	res.cid, err = arr[index].TryBytes()
+	res.Cid, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field cid: %w", err)
+		return fmt.Errorf("field Cid: %w", err)
 	}
 
 	index++
-	res.from, err = func (item stackitem.Item) (*keys.PublicKey, error) {
+	res.From, err = func (item stackitem.Item) (*keys.PublicKey, error) {
 		b, err := item.TryBytes()
 		if err != nil {
 			return nil, err
@@ -313,7 +313,7 @@ func (res *AuditauditHeader) FromStackItem(item stackitem.Item) error {
 		return k, nil
 	} (arr[index])
 	if err != nil {
-		return fmt.Errorf("field from: %w", err)
+		return fmt.Errorf("field From: %w", err)
 	}
 
 	return nil

--- a/rpc/container/rpcbinding.go
+++ b/rpc/container/rpcbinding.go
@@ -25,10 +25,10 @@ type CommonBallot struct {
 
 // ContainerContainer is a contract-specific container.Container type used by its methods.
 type ContainerContainer struct {
-	value []byte
-	sig []byte
-	pub *keys.PublicKey
-	token []byte
+	Value []byte
+	Sig []byte
+	Pub *keys.PublicKey
+	Token []byte
 }
 
 // ContainerEstimation is a contract-specific container.Estimation type used by its methods.
@@ -39,16 +39,16 @@ type ContainerEstimation struct {
 
 // ContainerExtendedACL is a contract-specific container.ExtendedACL type used by its methods.
 type ContainerExtendedACL struct {
-	value []byte
-	sig []byte
-	pub *keys.PublicKey
-	token []byte
+	Value []byte
+	Sig []byte
+	Pub *keys.PublicKey
+	Token []byte
 }
 
 // ContainercontainerSizes is a contract-specific container.containerSizes type used by its methods.
 type ContainercontainerSizes struct {
-	cid []byte
-	estimations []*ContainerEstimation
+	Cid []byte
+	Estimations []*ContainerEstimation
 }
 
 // LedgerBlock is a contract-specific ledger.Block type used by its methods.
@@ -616,19 +616,19 @@ func (res *ContainerContainer) FromStackItem(item stackitem.Item) error {
 		err error
 	)
 	index++
-	res.value, err = arr[index].TryBytes()
+	res.Value, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field value: %w", err)
+		return fmt.Errorf("field Value: %w", err)
 	}
 
 	index++
-	res.sig, err = arr[index].TryBytes()
+	res.Sig, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field sig: %w", err)
+		return fmt.Errorf("field Sig: %w", err)
 	}
 
 	index++
-	res.pub, err = func (item stackitem.Item) (*keys.PublicKey, error) {
+	res.Pub, err = func (item stackitem.Item) (*keys.PublicKey, error) {
 		b, err := item.TryBytes()
 		if err != nil {
 			return nil, err
@@ -640,13 +640,13 @@ func (res *ContainerContainer) FromStackItem(item stackitem.Item) error {
 		return k, nil
 	} (arr[index])
 	if err != nil {
-		return fmt.Errorf("field pub: %w", err)
+		return fmt.Errorf("field Pub: %w", err)
 	}
 
 	index++
-	res.token, err = arr[index].TryBytes()
+	res.Token, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field token: %w", err)
+		return fmt.Errorf("field Token: %w", err)
 	}
 
 	return nil
@@ -728,19 +728,19 @@ func (res *ContainerExtendedACL) FromStackItem(item stackitem.Item) error {
 		err error
 	)
 	index++
-	res.value, err = arr[index].TryBytes()
+	res.Value, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field value: %w", err)
+		return fmt.Errorf("field Value: %w", err)
 	}
 
 	index++
-	res.sig, err = arr[index].TryBytes()
+	res.Sig, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field sig: %w", err)
+		return fmt.Errorf("field Sig: %w", err)
 	}
 
 	index++
-	res.pub, err = func (item stackitem.Item) (*keys.PublicKey, error) {
+	res.Pub, err = func (item stackitem.Item) (*keys.PublicKey, error) {
 		b, err := item.TryBytes()
 		if err != nil {
 			return nil, err
@@ -752,13 +752,13 @@ func (res *ContainerExtendedACL) FromStackItem(item stackitem.Item) error {
 		return k, nil
 	} (arr[index])
 	if err != nil {
-		return fmt.Errorf("field pub: %w", err)
+		return fmt.Errorf("field Pub: %w", err)
 	}
 
 	index++
-	res.token, err = arr[index].TryBytes()
+	res.Token, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field token: %w", err)
+		return fmt.Errorf("field Token: %w", err)
 	}
 
 	return nil
@@ -790,13 +790,13 @@ func (res *ContainercontainerSizes) FromStackItem(item stackitem.Item) error {
 		err error
 	)
 	index++
-	res.cid, err = arr[index].TryBytes()
+	res.Cid, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field cid: %w", err)
+		return fmt.Errorf("field Cid: %w", err)
 	}
 
 	index++
-	res.estimations, err = func (item stackitem.Item) ([]*ContainerEstimation, error) {
+	res.Estimations, err = func (item stackitem.Item) ([]*ContainerEstimation, error) {
 		arr, ok := item.Value().([]stackitem.Item)
 		if !ok {
 			return nil, errors.New("not an array")
@@ -811,7 +811,7 @@ func (res *ContainercontainerSizes) FromStackItem(item stackitem.Item) error {
 		return res, nil
 	} (arr[index])
 	if err != nil {
-		return fmt.Errorf("field estimations: %w", err)
+		return fmt.Errorf("field Estimations: %w", err)
 	}
 
 	return nil

--- a/rpc/neofs/rpcbinding.go
+++ b/rpc/neofs/rpcbinding.go
@@ -149,8 +149,8 @@ type ManagementPermission struct {
 
 // Neofsrecord is a contract-specific neofs.record type used by its methods.
 type Neofsrecord struct {
-	key []byte
-	val []byte
+	Key []byte
+	Val []byte
 }
 
 // DepositEvent represents "Deposit" event emitted by the contract.
@@ -1869,15 +1869,15 @@ func (res *Neofsrecord) FromStackItem(item stackitem.Item) error {
 		err error
 	)
 	index++
-	res.key, err = arr[index].TryBytes()
+	res.Key, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field key: %w", err)
+		return fmt.Errorf("field Key: %w", err)
 	}
 
 	index++
-	res.val, err = arr[index].TryBytes()
+	res.Val, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field val: %w", err)
+		return fmt.Errorf("field Val: %w", err)
 	}
 
 	return nil

--- a/rpc/neofs/rpcbinding.go
+++ b/rpc/neofs/rpcbinding.go
@@ -147,8 +147,8 @@ type ManagementPermission struct {
 	Methods []string
 }
 
-// Neofsrecord is a contract-specific neofs.record type used by its methods.
-type Neofsrecord struct {
+// NeofsRecord is a contract-specific neofs.Record type used by its methods.
+type NeofsRecord struct {
 	Key []byte
 	Val []byte
 }
@@ -303,19 +303,19 @@ func (c *ContractReader) InnerRingCandidates() ([]*CommonIRNode, error) {
 }
 
 // ListConfig invokes `listConfig` method of contract.
-func (c *ContractReader) ListConfig() ([]*Neofsrecord, error) {
-	return func (item stackitem.Item, err error) ([]*Neofsrecord, error) {
+func (c *ContractReader) ListConfig() ([]*NeofsRecord, error) {
+	return func (item stackitem.Item, err error) ([]*NeofsRecord, error) {
 		if err != nil {
 			return nil, err
 		}
-		return func (item stackitem.Item) ([]*Neofsrecord, error) {
+		return func (item stackitem.Item) ([]*NeofsRecord, error) {
 			arr, ok := item.Value().([]stackitem.Item)
 			if !ok {
 				return nil, errors.New("not an array")
 			}
-			res := make([]*Neofsrecord, len(arr))
+			res := make([]*NeofsRecord, len(arr))
 			for i := range res {
-				res[i], err = itemToNeofsrecord(arr[i], nil)
+				res[i], err = itemToNeofsRecord(arr[i], nil)
 				if err != nil {
 					return nil, fmt.Errorf("item %d: %w", i, err)
 				}
@@ -1843,19 +1843,19 @@ func (res *ManagementPermission) FromStackItem(item stackitem.Item) error {
 	return nil
 }
 
-// itemToNeofsrecord converts stack item into *Neofsrecord.
-func itemToNeofsrecord(item stackitem.Item, err error) (*Neofsrecord, error) {
+// itemToNeofsRecord converts stack item into *NeofsRecord.
+func itemToNeofsRecord(item stackitem.Item, err error) (*NeofsRecord, error) {
 	if err != nil {
 		return nil, err
 	}
-	var res = new(Neofsrecord)
+	var res = new(NeofsRecord)
 	err = res.FromStackItem(item)
 	return res, err
 }
 
-// FromStackItem retrieves fields of Neofsrecord from the given
+// FromStackItem retrieves fields of NeofsRecord from the given
 // [stackitem.Item] or returns an error if it's not possible to do to so.
-func (res *Neofsrecord) FromStackItem(item stackitem.Item) error {
+func (res *NeofsRecord) FromStackItem(item stackitem.Item) error {
 	arr, ok := item.Value().([]stackitem.Item)
 	if !ok {
 		return errors.New("not an array")

--- a/rpc/netmap/rpcbinding.go
+++ b/rpc/netmap/rpcbinding.go
@@ -155,8 +155,8 @@ type NetmapNode struct {
 
 // Netmaprecord is a contract-specific netmap.record type used by its methods.
 type Netmaprecord struct {
-	key []byte
-	val []byte
+	Key []byte
+	Val []byte
 }
 
 // AddPeerSuccessEvent represents "AddPeerSuccess" event emitted by the contract.
@@ -1952,15 +1952,15 @@ func (res *Netmaprecord) FromStackItem(item stackitem.Item) error {
 		err error
 	)
 	index++
-	res.key, err = arr[index].TryBytes()
+	res.Key, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field key: %w", err)
+		return fmt.Errorf("field Key: %w", err)
 	}
 
 	index++
-	res.val, err = arr[index].TryBytes()
+	res.Val, err = arr[index].TryBytes()
 	if err != nil {
-		return fmt.Errorf("field val: %w", err)
+		return fmt.Errorf("field Val: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
And upgrade NeoGo to fetch the generator bugfix.

Close #349.