### PR TITLE
`go fmt` generated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog for NeoFS Contract
 - RPC bindings generation (#345)
 
 ### Updated
+- `neo-go` to `v0.103.1`
 
 ### Removed
 - old unused (notary-disabled) events (#341)

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Sidechain contracts:
 
 To compile smart contracts you need:
 
--   [neo-go](https://github.com/nspcc-dev/neo-go) >= 0.102.0
+-   [neo-go](https://github.com/nspcc-dev/neo-go) >= 0.103.1
 
 ## Compilation
 


### PR DESCRIPTION
btw we can go further and use `goimports` tool since imports are unsorted, but i decided to not do that for now

with these changes `make fmt` (`go fmt ./...`) becomes no-op