### PR TITLE
nns: fix expired TLD registration

### DIFF
--- a/nns/nns_contract.go
+++ b/nns/nns_contract.go
@@ -422,7 +422,7 @@ func saveCommitteeDomain(ctx storage.Context, name, email string, refresh, retry
 	}
 
 	tldKey := makeTLDKey(name)
-	if storage.Get(ctx, tldKey) != nil {
+	if storage.Get(ctx, tldKey) != nil && !parentExpired(ctx, 0, fragments) {
 		panic("TLD already exists")
 	}
 

--- a/tests/nns_test.go
+++ b/tests/nns_test.go
@@ -246,6 +246,8 @@ func TestExpiration(t *testing.T) {
 	c := newNNSInvoker(t, true)
 
 	refresh, retry, expire, ttl := int64(101), int64(102), int64(msPerYear/1000*10), int64(104)
+	c.Invoke(t, stackitem.Null{}, "registerTLD",
+		"newtld", "myemail@nspcc.ru", refresh, retry, expire, ttl)
 	c.Invoke(t, true, "register",
 		"testdomain.com", c.CommitteeHash,
 		"myemail@nspcc.ru", refresh, retry, expire, ttl)
@@ -278,6 +280,13 @@ func TestExpiration(t *testing.T) {
 
 	c.InvokeFail(t, "name has expired", "getAllRecords", "testdomain.com")
 	c.InvokeFail(t, "name has expired", "ownerOf", "testdomain.com")
+
+	c.InvokeFail(t, "name has expired", "renew", "newtld")
+	c.Invoke(t, stackitem.Null{}, "registerTLD",
+		"newtld", "myemail@nspcc.ru", refresh, retry, expire, ttl)
+	c.Invoke(t, true, "register",
+		"testdomain.com", c.CommitteeHash,
+		"myemail@nspcc.ru", refresh, retry, expire, ttl)
 }
 
 func TestNNSSetAdmin(t *testing.T) {


### PR DESCRIPTION
If a TLD has expired:
 * it can't be renewed because of "name has expired"
 * it can't be registered again because of "TLD already exists"

The first one is OK, but the second one is fixed here.