### PR TITLE
feat/Make `NewEpoch` callback mechanism more generic

### DIFF
--- a/alphabet/alphabet_contract.go
+++ b/alphabet/alphabet_contract.go
@@ -3,14 +3,11 @@ package alphabet
 import (
 	"github.com/nspcc-dev/neo-go/pkg/interop"
 	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
-	"github.com/nspcc-dev/neo-go/pkg/interop/convert"
-	"github.com/nspcc-dev/neo-go/pkg/interop/lib/address"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/gas"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/ledger"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/neo"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/notary"
-	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
 	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
 	"github.com/nspcc-dev/neo-go/pkg/interop/storage"
 	"github.com/nspcc-dev/neofs-contract/common"
@@ -113,26 +110,7 @@ func switchToNotary(ctx storage.Context, args []any) {
 				panic("address of the Proxy contract is missing or invalid")
 			}
 		} else {
-			// get NNS contract (it always has ID=1 in the NeoFS Sidechain)
-			nnsContract := management.GetContractByID(1)
-			if nnsContract == nil {
-				panic("missing NNS contract")
-			}
-
-			resResolve := contract.Call(nnsContract.Hash, "resolve", contract.ReadOnly,
-				"proxy.neofs", 16, // TXT
-			)
-
-			records := resResolve.([]string)
-			if len(records) == 0 {
-				panic("did not find a record of the Proxy contract in the NNS")
-			}
-
-			if len(records[0]) == 2*interop.Hash160Len {
-				proxyContract = convert.ToBytes(std.Atoi(records[0], 16))
-			} else {
-				proxyContract = address.ToHash160(records[0])
-			}
+			proxyContract = common.ResolveContractHash("proxy")
 		}
 
 		if !common.TryPurgeVotes(ctx) {

--- a/balance/balance_contract.go
+++ b/balance/balance_contract.go
@@ -78,6 +78,8 @@ func _deploy(data any, isUpdate bool) {
 		return
 	}
 
+	common.SubscribeForNewEpoch()
+
 	runtime.Log("balance contract initialized")
 }
 

--- a/balance/config.yml
+++ b/balance/config.yml
@@ -2,7 +2,7 @@ name: "NeoFS Balance"
 supportedstandards: ["NEP-17"]
 safemethods: ["balanceOf", "decimals", "symbol", "totalSupply", "version"]
 permissions:
-  - methods: ["update"]
+  - methods: ["update", "subscribeForNewEpoch"]
 events:
   - name: Lock
     parameters:

--- a/common/netmap.go
+++ b/common/netmap.go
@@ -1,0 +1,39 @@
+package common
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/interop"
+	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
+	"github.com/nspcc-dev/neo-go/pkg/interop/convert"
+	"github.com/nspcc-dev/neo-go/pkg/interop/lib/address"
+	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
+	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
+	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
+)
+
+// SubscribeForNewEpoch registers calling contract as a NewEpoch
+// callback requester. Netmap contract's address is taken from the
+// NNS contract, therefore, it must be presented and filled with
+// netmap information for a correct SubscribeForNewEpoch call; otherwise
+// a successive call is not guaranteed.
+// Caller must have `NewEpoch` method with a single numeric argument.
+func SubscribeForNewEpoch() {
+	nnsContract := management.GetContractByID(1)
+	if nnsContract == nil {
+		panic("missing NNS contract")
+	}
+
+	resolveRes := contract.Call(nnsContract.Hash, "resolve", contract.ReadOnly, "netmap.neofs", 16)
+	records := resolveRes.([]string)
+	if len(records) == 0 {
+		panic("did not find a record of the Netmap contract in the NNS")
+	}
+
+	var netmapContract interop.Hash160
+	if len(records[0]) == 2*interop.Hash160Len {
+		netmapContract = convert.ToBytes(std.Atoi(records[0], 16))
+	} else {
+		netmapContract = address.ToHash160(records[0])
+	}
+
+	contract.Call(netmapContract, "subscribeForNewEpoch", contract.All, runtime.GetExecutingScriptHash())
+}

--- a/common/netmap.go
+++ b/common/netmap.go
@@ -1,12 +1,7 @@
 package common
 
 import (
-	"github.com/nspcc-dev/neo-go/pkg/interop"
 	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
-	"github.com/nspcc-dev/neo-go/pkg/interop/convert"
-	"github.com/nspcc-dev/neo-go/pkg/interop/lib/address"
-	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
-	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
 	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
 )
 
@@ -17,23 +12,6 @@ import (
 // a successive call is not guaranteed.
 // Caller must have `NewEpoch` method with a single numeric argument.
 func SubscribeForNewEpoch() {
-	nnsContract := management.GetContractByID(1)
-	if nnsContract == nil {
-		panic("missing NNS contract")
-	}
-
-	resolveRes := contract.Call(nnsContract.Hash, "resolve", contract.ReadOnly, "netmap.neofs", 16)
-	records := resolveRes.([]string)
-	if len(records) == 0 {
-		panic("did not find a record of the Netmap contract in the NNS")
-	}
-
-	var netmapContract interop.Hash160
-	if len(records[0]) == 2*interop.Hash160Len {
-		netmapContract = convert.ToBytes(std.Atoi(records[0], 16))
-	} else {
-		netmapContract = address.ToHash160(records[0])
-	}
-
+	netmapContract := ResolveContractHash("netmap")
 	contract.Call(netmapContract, "subscribeForNewEpoch", contract.All, runtime.GetExecutingScriptHash())
 }

--- a/common/nns.go
+++ b/common/nns.go
@@ -1,0 +1,43 @@
+package common
+
+import (
+	"github.com/nspcc-dev/neo-go/pkg/interop"
+	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
+	"github.com/nspcc-dev/neo-go/pkg/interop/convert"
+	"github.com/nspcc-dev/neo-go/pkg/interop/lib/address"
+	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
+	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
+)
+
+// ResolveContractHash resolves contract hash by its well-known NeoFS name.
+// Contract name should be lowercased, should not include `.neofs` TLD. Example
+// values: "netmap", "container", etc.
+// Relies on some NeoFS specifics:
+//  1. NNS contract should be deployed first (and should have `1` contract ID)
+//  2. It should be prefilled with contract hashes by their names (no
+//     capitalized chars; no `neofs` TLD)
+func ResolveContractHash(contractName string) interop.Hash160 {
+	// get NNS contract (it always has ID=1 in the NeoFS Sidechain)
+	nnsContract := management.GetContractByID(1)
+	if nnsContract == nil {
+		panic("missing NNS contract")
+	}
+
+	resResolve := contract.Call(nnsContract.Hash, "resolve", contract.ReadOnly,
+		contractName+".neofs", 16, // TXT
+	)
+
+	records := resResolve.([]string)
+	if len(records) == 0 {
+		panic("did not find a record of the " + contractName + " contract in the NNS")
+	}
+
+	var hash interop.Hash160
+	if len(records[0]) == 2*interop.Hash160Len {
+		hash = convert.ToBytes(std.Atoi(records[0], 16))
+	} else {
+		hash = address.ToHash160(records[0])
+	}
+
+	return hash
+}

--- a/container/config.yml
+++ b/container/config.yml
@@ -2,7 +2,7 @@ name: "NeoFS Container"
 safemethods: ["alias", "count", "containersOf", "get", "owner", "list", "eACL", "getContainerSize", "listContainerSizes", "iterateContainerSizes", "iterateAllContainerSizes", "version"]
 permissions:
   - methods: ["update", "addKey", "transferX",
-              "register", "registerTLD", "addRecord", "deleteRecords"]
+              "register", "registerTLD", "addRecord", "deleteRecords", "subscribeForNewEpoch"]
 events:
   - name: PutSuccess
     parameters:

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -203,7 +203,7 @@ func switchToNotary(ctx storage.Context) {
 // nolint:deadcode,unused
 func registerNiceNameTLD(addrNNS interop.Hash160, nnsRoot string) {
 	isAvail := contract.Call(addrNNS, "isAvailable", contract.AllowCall|contract.ReadStates,
-		"container").(bool)
+		nnsRoot).(bool)
 	if !isAvail {
 		return
 	}

--- a/container/container_contract.go
+++ b/container/container_contract.go
@@ -169,6 +169,8 @@ func _deploy(data any, isUpdate bool) {
 	// add NNS root for container alias domains
 	registerNiceNameTLD(args.addrNNS, args.nnsRoot)
 
+	common.SubscribeForNewEpoch()
+
 	runtime.Log("container contract initialized")
 }
 

--- a/netmap/config.yml
+++ b/netmap/config.yml
@@ -17,3 +17,7 @@ events:
     parameters:
       - name: epoch
         type: Integer
+  - name: NewEpochSubscription
+    parameters:
+      - name: contract
+        type: Hash160

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -71,8 +71,10 @@ const (
 	snapshotEpoch        = "snapshotEpoch"
 	snapshotBlockKey     = "snapshotBlock"
 
+	// nolint:unused // used only in _deploy func which is nolinted too
 	containerContractKey = "containerScriptHash"
-	balanceContractKey   = "balanceScriptHash"
+	// nolint:unused // used only in _deploy func which is nolinted too
+	balanceContractKey = "balanceScriptHash"
 
 	newEpochSubscribersPrefix = "e"
 	cleanupEpochMethod        = "newEpoch"

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -623,8 +623,13 @@ func SubscribeForNewEpoch(contract interop.Hash160) {
 
 	ctx := storage.GetContext()
 	var num byte
-	it := storage.Find(ctx, []byte(newEpochSubscribersPrefix), storage.None)
+	it := storage.Find(ctx, []byte(newEpochSubscribersPrefix), storage.KeysOnly|storage.RemovePrefix)
 	for iterator.Next(it) {
+		raw := iterator.Value(it).([]byte)[1:] // 1 byte is an index
+		if contract.Equals(raw) {
+			return
+		}
+
 		num += 1
 	}
 

--- a/netmap/netmap_contract.go
+++ b/netmap/netmap_contract.go
@@ -4,6 +4,7 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/interop"
 	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
 	"github.com/nspcc-dev/neo-go/pkg/interop/iterator"
+	"github.com/nspcc-dev/neo-go/pkg/interop/lib/address"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/ledger"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/std"
@@ -615,6 +616,10 @@ func ListConfig() []record {
 // registered recipient in a success case.
 func SubscribeForNewEpoch(contract interop.Hash160) {
 	common.CheckAlphabetWitness(common.AlphabetAddress())
+
+	if !management.HasMethod(contract, "newEpoch", 1) {
+		panic(address.FromHash160(contract) + " contract does not have `newEpoch(epoch)` method")
+	}
 
 	ctx := storage.GetContext()
 	var num byte

--- a/tests/alphabet_test.go
+++ b/tests/alphabet_test.go
@@ -35,18 +35,17 @@ func deployAlphabetContract(t *testing.T, e *neotest.Executor, addrNetmap, addrP
 func newAlphabetInvoker(t *testing.T) (*neotest.Executor, *neotest.ContractInvoker) {
 	e := newExecutor(t)
 
-	ctrNNS := neotest.CompileFile(t, e.CommitteeHash, nnsPath, path.Join(nnsPath, "config.yml"))
 	ctrNetmap := neotest.CompileFile(t, e.CommitteeHash, netmapPath, path.Join(netmapPath, "config.yml"))
 	ctrBalance := neotest.CompileFile(t, e.CommitteeHash, balancePath, path.Join(balancePath, "config.yml"))
 	ctrContainer := neotest.CompileFile(t, e.CommitteeHash, containerPath, path.Join(containerPath, "config.yml"))
 	ctrProxy := neotest.CompileFile(t, e.CommitteeHash, proxyPath, path.Join(proxyPath, "config.yml"))
 
-	e.DeployContract(t, ctrNNS, nil)
-	deployNetmapContract(t, e, ctrBalance.Hash, ctrContainer.Hash,
+	nnsInvoker := deployNNSWithTLDs(t, e, "neofs")
+	deployNetmapContract(t, e, nnsInvoker.Hash,
 		container.RegistrationFeeKey, int64(containerFee),
 		container.AliasFeeKey, int64(containerAliasFee))
 	deployBalanceContract(t, e, ctrNetmap.Hash, ctrContainer.Hash)
-	deployContainerContract(t, e, ctrNetmap.Hash, ctrBalance.Hash, ctrNNS.Hash)
+	deployContainerContract(t, e, ctrNetmap.Hash, ctrBalance.Hash, nnsInvoker.Hash)
 	deployProxyContract(t, e, ctrNetmap.Hash)
 	hash := deployAlphabetContract(t, e, ctrNetmap.Hash, ctrProxy.Hash, "Az", 0, 1)
 

--- a/tests/container_test.go
+++ b/tests/container_test.go
@@ -43,17 +43,16 @@ func deployContainerContract(t *testing.T, e *neotest.Executor, addrNetmap, addr
 func newContainerInvoker(t *testing.T) (*neotest.ContractInvoker, *neotest.ContractInvoker, *neotest.ContractInvoker) {
 	e := newExecutor(t)
 
-	ctrNNS := neotest.CompileFile(t, e.CommitteeHash, nnsPath, path.Join(nnsPath, "config.yml"))
 	ctrNetmap := neotest.CompileFile(t, e.CommitteeHash, netmapPath, path.Join(netmapPath, "config.yml"))
 	ctrBalance := neotest.CompileFile(t, e.CommitteeHash, balancePath, path.Join(balancePath, "config.yml"))
 	ctrContainer := neotest.CompileFile(t, e.CommitteeHash, containerPath, path.Join(containerPath, "config.yml"))
 
-	e.DeployContract(t, ctrNNS, nil)
-	deployNetmapContract(t, e, ctrBalance.Hash, ctrContainer.Hash,
+	nnsInvoker := deployNNSWithTLDs(t, e, "neofs")
+	deployNetmapContract(t, e, nnsInvoker.Hash,
 		container.RegistrationFeeKey, int64(containerFee),
 		container.AliasFeeKey, int64(containerAliasFee))
 	deployBalanceContract(t, e, ctrNetmap.Hash, ctrContainer.Hash)
-	deployContainerContract(t, e, ctrNetmap.Hash, ctrBalance.Hash, ctrNNS.Hash)
+	deployContainerContract(t, e, ctrNetmap.Hash, ctrBalance.Hash, nnsInvoker.Hash)
 	return e.CommitteeInvoker(ctrContainer.Hash), e.CommitteeInvoker(ctrBalance.Hash), e.CommitteeInvoker(ctrNetmap.Hash)
 }
 

--- a/tests/container_test.go
+++ b/tests/container_test.go
@@ -33,7 +33,7 @@ func deployContainerContract(t *testing.T, e *neotest.Executor, addrNetmap, addr
 	args[2] = addrBalance
 	args[3] = util.Uint160{} // not needed for now
 	args[4] = addrNNS
-	args[5] = "neofs"
+	args[5] = "container"
 
 	c := neotest.CompileFile(t, e.CommitteeHash, containerPath, path.Join(containerPath, "config.yml"))
 	e.DeployContract(t, c, args)
@@ -196,15 +196,15 @@ func TestContainerPut(t *testing.T) {
 			stackitem.NewByteArray([]byte(base58.Encode(cnt.id[:]))),
 		})
 		cNNS := c.CommitteeInvoker(nnsHash)
-		cNNS.Invoke(t, expected, "resolve", "mycnt.neofs", int64(nns.TXT))
-		c.Invoke(t, stackitem.NewByteArray([]byte("mycnt.neofs")), "alias", cnt.id[:])
+		cNNS.Invoke(t, expected, "resolve", "mycnt.container", int64(nns.TXT))
+		c.Invoke(t, stackitem.NewByteArray([]byte("mycnt.container")), "alias", cnt.id[:])
 
 		t.Run("name is already taken", func(t *testing.T) {
 			c.InvokeFail(t, "name is already taken", "putNamed", putArgs...)
 		})
 
 		c.Invoke(t, stackitem.Null{}, "delete", cnt.id[:], cnt.sig, cnt.token)
-		cNNS.Invoke(t, stackitem.Null{}, "resolve", "mycnt.neofs", int64(nns.TXT))
+		cNNS.Invoke(t, stackitem.Null{}, "resolve", "mycnt.container", int64(nns.TXT))
 
 		t.Run("register in advance", func(t *testing.T) {
 			cnt.value[len(cnt.value)-1] = 10

--- a/tests/migration/storage.go
+++ b/tests/migration/storage.go
@@ -252,6 +252,13 @@ func (x *Contract) GetStorageItem(key []byte) []byte {
 	return x.exec.Chain.GetStorageItem(x.id, key)
 }
 
+// SeekStorage calls a provided handler against every stored item that starts
+// with a provided prefix. On handler's `false` return stops iteration. prefix
+// is removed from the resulting pair's key.
+func (x *Contract) SeekStorage(prefix []byte, handler func(k, v []byte) bool) {
+	x.exec.Chain.SeekStorage(x.id, prefix, handler)
+}
+
 // RegisterContractInNNS binds given address to the contract referenced by
 // provided name via additional record for the 'name.neofs' domain in the NeoFS
 // NNS contract. The method is useful when tested contract uses NNS to access

--- a/tests/neofsid_test.go
+++ b/tests/neofsid_test.go
@@ -32,17 +32,16 @@ func deployNeoFSIDContract(t *testing.T, e *neotest.Executor, addrNetmap, addrCo
 func newNeoFSIDInvoker(t *testing.T) *neotest.ContractInvoker {
 	e := newExecutor(t)
 
-	ctrNNS := neotest.CompileFile(t, e.CommitteeHash, nnsPath, path.Join(nnsPath, "config.yml"))
 	ctrNetmap := neotest.CompileFile(t, e.CommitteeHash, netmapPath, path.Join(netmapPath, "config.yml"))
 	ctrBalance := neotest.CompileFile(t, e.CommitteeHash, balancePath, path.Join(balancePath, "config.yml"))
 	ctrContainer := neotest.CompileFile(t, e.CommitteeHash, containerPath, path.Join(containerPath, "config.yml"))
 
-	e.DeployContract(t, ctrNNS, nil)
-	deployNetmapContract(t, e, ctrBalance.Hash, ctrContainer.Hash,
+	nnsInvoker := deployNNSWithTLDs(t, e, "neofs")
+	deployNetmapContract(t, e, nnsInvoker.Hash,
 		container.RegistrationFeeKey, int64(containerFee),
 		container.AliasFeeKey, int64(containerAliasFee))
 	deployBalanceContract(t, e, ctrNetmap.Hash, ctrContainer.Hash)
-	deployContainerContract(t, e, ctrNetmap.Hash, ctrBalance.Hash, ctrNNS.Hash)
+	deployContainerContract(t, e, ctrNetmap.Hash, ctrBalance.Hash, nnsInvoker.Hash)
 	h := deployNeoFSIDContract(t, e, ctrNetmap.Hash, ctrContainer.Hash)
 	return e.CommitteeInvoker(h)
 }

--- a/tests/nns_test.go
+++ b/tests/nns_test.go
@@ -21,6 +21,17 @@ const nnsPath = "../nns"
 
 const msPerYear = 365 * 24 * time.Hour / time.Millisecond
 
+func deployNNSWithTLDs(t *testing.T, e *neotest.Executor, tlds ...string) *neotest.ContractInvoker {
+	ctr := neotest.CompileFile(t, e.CommitteeHash, nnsPath, path.Join(nnsPath, "config.yml"))
+	_tldSet := make([]any, len(tlds))
+	for i := range tlds {
+		_tldSet[i] = []any{tlds[i], "user@domain.org"}
+	}
+	e.DeployContract(t, ctr, []any{_tldSet})
+
+	return e.CommitteeInvoker(ctr.Hash)
+}
+
 func newNNSInvoker(t *testing.T, addRoot bool, tldSet ...string) *neotest.ContractInvoker {
 	e := newExecutor(t)
 	ctr := neotest.CompileFile(t, e.CommitteeHash, nnsPath, path.Join(nnsPath, "config.yml"))

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -24,11 +24,10 @@ func newProxyInvoker(t *testing.T) *neotest.ContractInvoker {
 	e := newExecutor(t)
 
 	ctrNetmap := neotest.CompileFile(t, e.CommitteeHash, netmapPath, path.Join(netmapPath, "config.yml"))
-	ctrBalance := neotest.CompileFile(t, e.CommitteeHash, balancePath, path.Join(balancePath, "config.yml"))
-	ctrContainer := neotest.CompileFile(t, e.CommitteeHash, containerPath, path.Join(containerPath, "config.yml"))
 	ctrProxy := neotest.CompileFile(t, e.CommitteeHash, proxyPath, path.Join(proxyPath, "config.yml"))
 
-	deployNetmapContract(t, e, ctrBalance.Hash, ctrContainer.Hash)
+	nnsInvoker := deployNNSWithTLDs(t, e, "neofs")
+	deployNetmapContract(t, e, nnsInvoker.Hash)
 	deployProxyContract(t, e, ctrNetmap.Hash)
 
 	return e.CommitteeInvoker(ctrProxy.Hash)


### PR DESCRIPTION
Do not hardcode container and balance contract as a `NewEpoch` events receivers in the netmap contract. Use the netmap's registration method on a deploy stage instead.