### PR TITLE
nns: fix deployments with 0.38.1 adm

### DIFF
--- a/nns/nns_contract.go
+++ b/nns/nns_contract.go
@@ -133,24 +133,32 @@ func _deploy(data any, isUpdate bool) {
 	storage.Put(ctx, []byte{prefixTotalSupply}, 0)
 	storage.Put(ctx, []byte{prefixRegisterPrice}, defaultRegisterPrice)
 
-	if data != nil { // for backward compatibility
-		args := data.(struct {
-			tldSet []struct {
-				name  string
-				email string
-			}
-		})
+	if data == nil { // TLDs are optional.
+		return
+	}
 
-		for i := range args.tldSet {
-			const (
-				refresh = 3600
-				retry   = 600
-				expire  = 10 * 365 * 24 * 60 * 60 // 10 years
-				ttl     = 3600
-			)
-			saveCommitteeDomain(ctx, args.tldSet[i].name, args.tldSet[i].email, refresh, retry, expire, ttl)
-			runtime.Log("registered committee domain " + args.tldSet[i].name)
+	s := data.([]any)
+
+	if len(s) == 0 { // pre-0.39.0 neofs-adm happily pushes an empty slice into data
+		return
+	}
+
+	args := data.(struct {
+		tldSet []struct {
+			name  string
+			email string
 		}
+	})
+
+	for i := range args.tldSet {
+		const (
+			refresh = 3600
+			retry   = 600
+			expire  = 10 * 365 * 24 * 60 * 60 // 10 years
+			ttl     = 3600
+		)
+		saveCommitteeDomain(ctx, args.tldSet[i].name, args.tldSet[i].email, refresh, retry, expire, ttl)
+		runtime.Log("registered committee domain " + args.tldSet[i].name)
 	}
 }
 

--- a/tests/nns_test.go
+++ b/tests/nns_test.go
@@ -71,6 +71,12 @@ func TestNNSGeneric(t *testing.T) {
 	c.Invoke(t, 0, "totalSupply")
 }
 
+func TestOldAdmDeploy(t *testing.T) {
+	e := newExecutor(t)
+	ctr := neotest.CompileFile(t, e.CommitteeHash, nnsPath, path.Join(nnsPath, "config.yml"))
+	e.DeployContract(t, ctr, []any{})
+}
+
 func TestNNSRegisterTLD(t *testing.T) {
 	c := newNNSInvoker(t, false)
 


### PR DESCRIPTION
I'm not yet sure we need it, but old adm (before nspcc-dev/neofs-node#2625) creates a broken deploy script with actual data that has no fields inside. Not a problem for updates, not a problem for newer adm, but still.