### PR TITLE
alphabet: Add `verify` method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Changelog for NeoFS Contract
 ## [Unreleased]
 
 ### Added
+- `verify` method for Alphabet contracts (#386)
 
 ### Updated
 

--- a/common/ir.go
+++ b/common/ir.go
@@ -74,3 +74,13 @@ func Multiaddress(n []interop.PublicKey, committee bool) []byte {
 
 	return contract.CreateMultisigAccount(threshold, n)
 }
+
+// ContainsAlphabetWitness checks whether carrier transaction contains either
+// (2/3N + 1) or (N/2 + 1) valid multi-signature of the NeoFS Alphabet.
+func ContainsAlphabetWitness() bool {
+	alphabet := neo.GetCommittee()
+	if runtime.CheckWitness(Multiaddress(alphabet, false)) {
+		return true
+	}
+	return runtime.CheckWitness(Multiaddress(alphabet, true))
+}

--- a/contracts/alphabet/config.yml
+++ b/contracts/alphabet/config.yml
@@ -1,4 +1,4 @@
 name: "NeoFS Alphabet"
-safemethods: ["gas", "neo", "name", "version"]
+safemethods: ["gas", "neo", "name", "version", "verify"]
 permissions:
   - methods: ["update", "transfer", "vote"]

--- a/contracts/alphabet/contract.go
+++ b/contracts/alphabet/contract.go
@@ -340,3 +340,9 @@ func Name() string {
 func Version() int {
 	return common.Version
 }
+
+// Verify checks whether carrier transaction contains either (2/3N + 1) or
+// (N/2 + 1) valid multi-signature of the NeoFS Alphabet.
+func Verify() bool {
+	return common.ContainsAlphabetWitness()
+}

--- a/contracts/proxy/contract.go
+++ b/contracts/proxy/contract.go
@@ -5,7 +5,6 @@ import (
 	"github.com/nspcc-dev/neo-go/pkg/interop/contract"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/gas"
 	"github.com/nspcc-dev/neo-go/pkg/interop/native/management"
-	"github.com/nspcc-dev/neo-go/pkg/interop/native/neo"
 	"github.com/nspcc-dev/neo-go/pkg/interop/runtime"
 	"github.com/nspcc-dev/neofs-contract/common"
 )
@@ -41,18 +40,10 @@ func Update(script []byte, manifest []byte, data any) {
 	runtime.Log("proxy contract updated")
 }
 
-// Verify method returns true if transaction contains valid multisignature of
-// Alphabet nodes of the Inner Ring.
+// Verify checks whether carrier transaction contains either (2/3N + 1) or
+// (N/2 + 1) valid multi-signature of the NeoFS Alphabet.
 func Verify() bool {
-	alphabet := neo.GetCommittee()
-	sig := common.Multiaddress(alphabet, false)
-
-	if !runtime.CheckWitness(sig) {
-		sig = common.Multiaddress(alphabet, true)
-		return runtime.CheckWitness(sig)
-	}
-
-	return true
+	return common.ContainsAlphabetWitness()
 }
 
 // Version returns the version of the contract.

--- a/rpc/alphabet/rpcbinding.go
+++ b/rpc/alphabet/rpcbinding.go
@@ -78,6 +78,11 @@ func (c *ContractReader) Neo() (*big.Int, error) {
 	return unwrap.BigInt(c.invoker.Call(c.hash, "neo"))
 }
 
+// Verify invokes `verify` method of contract.
+func (c *ContractReader) Verify() (bool, error) {
+	return unwrap.Bool(c.invoker.Call(c.hash, "verify"))
+}
+
 // Version invokes `version` method of contract.
 func (c *ContractReader) Version() (*big.Int, error) {
 	return unwrap.BigInt(c.invoker.Call(c.hash, "version"))

--- a/tests/alphabet_test.go
+++ b/tests/alphabet_test.go
@@ -154,3 +154,8 @@ func getAlphabetAcc(t *testing.T, e *neotest.Executor) *wallet.Account {
 
 	return multi.Single(0).Account()
 }
+
+func TestAlphabetVerify(t *testing.T) {
+	_, contract := newAlphabetInvoker(t, false)
+	testVerify(t, contract)
+}

--- a/tests/helpers.go
+++ b/tests/helpers.go
@@ -2,10 +2,22 @@ package tests
 
 import (
 	"math/rand"
+	"testing"
+
+	"github.com/nspcc-dev/neo-go/pkg/neotest"
+	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
 func randomBytes(n int) []byte {
 	a := make([]byte, n)
 	rand.Read(a) //nolint:staticcheck // SA1019: rand.Read has been deprecated since Go 1.20
 	return a
+}
+
+// tests contract's 'verify' method checking whether carrier transaction is
+// signed by the NeoFS Alphabet.
+func testVerify(t testing.TB, contract *neotest.ContractInvoker) {
+	const method = "verify"
+	contract.Invoke(t, stackitem.NewBool(true), method)
+	contract.WithSigners(contract.NewAccount(t)).Invoke(t, stackitem.NewBool(false), method)
 }

--- a/tests/proxy_test.go
+++ b/tests/proxy_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/nspcc-dev/neo-go/pkg/neotest"
 	"github.com/nspcc-dev/neo-go/pkg/util"
-	"github.com/nspcc-dev/neo-go/pkg/vm/stackitem"
 )
 
 const proxyPath = "../contracts/proxy"
@@ -29,15 +28,6 @@ func newProxyInvoker(t *testing.T) *neotest.ContractInvoker {
 	return e.CommitteeInvoker(ctrProxy.Hash)
 }
 
-func TestVerify(t *testing.T) {
-	e := newProxyInvoker(t)
-
-	const method = "verify"
-
-	e.Invoke(t, stackitem.NewBool(true), method)
-
-	notAlphabet := e.NewAccount(t)
-	cNotAlphabet := e.WithSigners(notAlphabet)
-
-	cNotAlphabet.Invoke(t, stackitem.NewBool(false), method)
+func TestProxyVerify(t *testing.T) {
+	testVerify(t, newProxyInvoker(t))
 }


### PR DESCRIPTION
There is no way to move NEO from the Alphabet contracts right now. This can be needed for some migrations or fixes.

Proxy contract already had this method, so functionality is shared b/w them.

Closes #386.