### PR TITLE
deploy: copy transaction expected to be changed

### DIFF
--- a/deploy/notary.go
+++ b/deploy/notary.go
@@ -831,6 +831,8 @@ func makeUnsignedDesignateCommitteeNotaryTx(roleContract *rolemgmt.Contract, com
 		return nil, err
 	}
 
+	tx = tx.Copy()
+
 	tx.ValidUntilBlock = sharedTxData.validUntilBlock
 	tx.Nonce = sharedTxData.nonce
 	tx.Signers[0].Account = sharedTxData.sender


### PR DESCRIPTION
The whole `makeUnsignedDesignateCommitteeNotaryTx` is designed to be called many times if something goes wrong. But currently neo-go's actor shares signers with TXs it produces, so the actor is broken immediately after this func is called. Can be seen only if transaction-to-sign is expired, in practice happened when deployment nodes were started with a huge delay.