### PR TITLE
alphabet: drop glagolitsa

### DIFF
--- a/contracts/alphabet/contract.go
+++ b/contracts/alphabet/contract.go
@@ -329,7 +329,7 @@ func Vote(epoch int, candidates []interop.PublicKey) {
 	}
 }
 
-// Name returns the Glagolitic name of the contract.
+// Name returns the name of the contract set at deployment stage.
 func Name() string {
 	ctx := storage.GetReadOnlyContext()
 	return name(ctx)

--- a/contracts/alphabet/doc.go
+++ b/contracts/alphabet/doc.go
@@ -8,11 +8,10 @@ However, some of them may be malicious, and some NEO can be lost. It will destab
 the economics of FS chain. To avoid it, all 100,000,000 NEO are
 distributed among all alphabet contracts.
 
-To identify alphabet contracts, they are named with letters of the Glagolitic alphabet.
-Names are set at contract deploy. Alphabet nodes of the Inner Ring communicate with
-one of the alphabetical contracts to emit GAS. To vote for a new list of side
-chain committee, alphabet nodes of the Inner Ring create multisignature transactions
-for each alphabet contract.
+To identify alphabet contracts, they are named, names are set at contract deploy.
+Alphabet nodes of the Inner Ring communicate with one of the alphabetical contracts
+to emit GAS. To vote for a new list of side chain committee, alphabet nodes of
+the Inner Ring create multisignature transactions for each alphabet contract.
 
 # Contract notifications
 
@@ -30,7 +29,7 @@ Key-value storage format:
  - 'proxyScriptHash' -> interop.Hash160
    Proxy contract reference
  - 'name' -> string
-   name (Glagolitic letter) of the contract
+   name of the contract set at its deployment
  - 'index' -> int
    member index in the Alphabet list
  - 'threshold' -> int

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -110,12 +110,6 @@ type ReputationContractPrm struct {
 	Common CommonDeployPrm
 }
 
-// Glagolitsa is used for alphabet contract deploy routine.
-type Glagolitsa interface {
-	Size() int
-	LetterByIndex(ind int) string
-}
-
 // Prm groups all parameters of the FS chain deployment procedure.
 type Prm struct {
 	// Writes progress into the log.
@@ -140,8 +134,6 @@ type Prm struct {
 	NetmapContract     NetmapContractPrm
 	ProxyContract      ProxyContractPrm
 	ReputationContract ReputationContractPrm
-
-	Glagolitsa Glagolitsa
 }
 
 // Deploy initializes Neo network represented by given Prm.Blockchain as FS
@@ -568,7 +560,7 @@ func Deploy(ctx context.Context, prm Prm) error {
 
 	var alphabetContracts []util.Uint160
 
-	for ind := 0; ind < len(committee) && ind < prm.Glagolitsa.Size(); ind++ {
+	for ind := range committee {
 		syncPrm.tryDeploy = ind == localAccCommitteeIndex // each member deploys its own Alphabet contract
 		if !syncPrm.tryDeploy {
 			temp := committee[ind].GetScriptHash()
@@ -580,7 +572,7 @@ func Deploy(ctx context.Context, prm Prm) error {
 				notaryDisabledExtraUpdateArg,
 				netmapContractAddress,
 				proxyContractAddress,
-				prm.Glagolitsa.LetterByIndex(ind),
+				syncPrm.domainName,
 				ind,
 				len(committee),
 			}, nil


### PR DESCRIPTION
From the contract perspective it's just a name, can be "candy", can be "whiskey", can be whatever. Standard deployment routine can just use the same name as for NNS.

Related to https://github.com/nspcc-dev/neofs-node/issues/2422.