### PR TITLE
deploy: fix off by one error in block monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Changelog for NeoFS Contract
 ### Removed
 
 ### Fixed
+- Waiting for one more block in deployment code (#530)
 
 ## [0.24.0] - 2025-10-06
 

--- a/deploy/util.go
+++ b/deploy/util.go
@@ -47,7 +47,7 @@ func newBlockchainMonitor(l *zap.Logger, b Blockchain, chNewBlock chan<- struct{
 		return nil, fmt.Errorf("request Neo protocol configuration: %w", err)
 	}
 
-	initialBlock, err := b.GetBlockCount()
+	initialBlockCount, err := b.GetBlockCount()
 	if err != nil {
 		return nil, fmt.Errorf("get current blockchain height: %w", err)
 	}
@@ -65,7 +65,7 @@ func newBlockchainMonitor(l *zap.Logger, b Blockchain, chNewBlock chan<- struct{
 		chExit:        make(chan struct{}),
 	}
 
-	res.height.Store(initialBlock)
+	res.height.Store(initialBlockCount - 1)
 
 	go func() {
 		l.Info("listening to new blocks...")


### PR DESCRIPTION
Block count is not block height, so this was always initialized improperly which can lead to missing one block event (and reacting only to subsequent one) when deploying a contract with a freshly initialized monitor.