### PR TITLE
.github: upgrade actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,10 +31,10 @@ jobs:
             go: '1.25'
       fail-fast: false
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7
 
     - name: Set up Go
-      uses: actions/setup-go@v5
+      uses: actions/setup-go@v6
       with:
         go-version: '${{ matrix.go }}'
 
@@ -48,10 +48,10 @@ jobs:
     env:
       CGO_ENABLED: 0
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
           cache: true
@@ -60,7 +60,7 @@ jobs:
         run: go test -v ./... -coverprofile=./coverage.txt -coverpkg=./contracts/... -timeout 20m
 
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true # if something is wrong on uploading codecov results, then this job will fail
           files: ./coverage.txt
@@ -72,10 +72,10 @@ jobs:
     name: Build contracts and RPC bindings
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26'
 


### PR DESCRIPTION
Fetch fresh version of some GH actions to avoid deprecated Node.js warnings.